### PR TITLE
switch compilerOptions.jsx from react-jsx to react and move Button to src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ yarn-error.log*
 .env.production.local
 
 storybook-static
+
+@chromaui

--- a/src/Button.stories.tsx
+++ b/src/Button.stories.tsx
@@ -1,7 +1,7 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import React, { Meta, StoryObj } from '@storybook/react';
 
-import { Button } from './index';
-import { colors } from '../tokens';
+import { Button } from './Button';
+import { colors } from './tokens';
 
 const meta: Meta<typeof Button> = {
   title: 'Button',

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -1,7 +1,7 @@
+import React, { FC } from 'react';
 import { styled } from '@storybook/theming';
-import { colors } from '../tokens';
-import { FC } from 'react';
-import { Icon, IconType } from '../icon';
+import { colors } from './tokens';
+import { Icon, IconType } from './icon';
 
 export interface ButtonProps {
   children: String;

--- a/src/icon/iconPaths.tsx
+++ b/src/icon/iconPaths.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export const icons = {
   user: (
     <>

--- a/src/icon/index.tsx
+++ b/src/icon/index.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import React, { FC } from 'react';
 import { icons } from './iconPaths';
 import { colors } from '../tokens';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { colors } from './tokens';
-export { Button } from './button';
+export { Button } from './Button/Button';
 export { Icon } from './icon';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "module": "ESNext",
     "moduleResolution": "node",
     "skipLibCheck": true,


### PR DESCRIPTION
* Switched the mechanism for `compilerOptions.jsx`
* Moved button to src. We shouldn't used folders unless there's a bunch of files for a components. Otherwise we end up with multiple `index.ts` files which makes it hard to switch between files. 