### PR TITLE
Remove global style

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -9,7 +9,8 @@ const { GlobalStyle: StorybookDSGlobalStyle } = designSystemGlobal;
 
 const withGlobalStyle: Decorator = (storyFn) => (
   <>
-    <StorybookDSGlobalStyle />
+    {/* I removed the global style to make sure we are setting every elements on each components instead of relying on global styles. */}
+    {/* <StorybookDSGlobalStyle /> */}
     {storyFn()}
   </>
 );


### PR DESCRIPTION
To make sure we add all values to each components I'm removing the global style applied in preview. This way we can test that the component will work everywhere no matter the set up in global styles.