### PR TITLE
Fix lineHeight on heading16 and body16

### DIFF
--- a/src/_helpers/typography.ts
+++ b/src/_helpers/typography.ts
@@ -181,7 +181,7 @@ const heading18 = css`
 const heading16 = css`
   font-family: ${fontFamily.sans};
   font-size: ${fontSize[16]};
-  line-height: ${lineHeight[24]};
+  line-height: ${lineHeight[28]};
   font-weight: ${fontWeight.semibold};
 `;
 
@@ -195,7 +195,7 @@ const body18 = css`
 const body16 = css`
   font-family: ${fontFamily.sans};
   font-size: ${fontSize[16]};
-  line-height: ${lineHeight[24]};
+  line-height: ${lineHeight[28]};
   font-weight: ${fontWeight.regular};
 `;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,32 +1,8 @@
 // Tokens
 export * from './_tokens';
 
-// Helpers
-export {
-  minBase,
-  minSm,
-  minMd,
-  minLg,
-  minXl,
-  min2xl,
-  maxSm,
-  maxMd,
-  maxLg,
-  maxXl,
-  max2xl,
-  heading4xl, // To be removed
-  heading3xl, // To be removed
-  heading2xl, // To be removed
-  headingXl, // To be removed
-  headingLg, // To be removed
-  headingMd, // To be removed
-  headingSm, // To be removed
-  headingXs, // To be removed
-  bodyLg, // To be removed
-  bodyMd, // To be removed
-  bodySm, // To be removed
-  type,
-} from './_helpers';
+// Typography
+export * from './_helpers/typography';
 
 // Hooks
 export { useMediaQuery } from './_hooks/useMediaQuery';


### PR DESCRIPTION
- Fix lineHeight on `heading16`
- Fix lineHeight on `body16`
- Improve the way we export typography
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.10.18--canary.52.0b12936.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/tetra@1.10.18--canary.52.0b12936.0
  # or 
  yarn add @chromaui/tetra@1.10.18--canary.52.0b12936.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
