### PR TITLE
fix compact mode for Testimonial and use theme prop for dark/light modes

### DIFF
--- a/src/Header/Header.stories.tsx
+++ b/src/Header/Header.stories.tsx
@@ -70,7 +70,7 @@ export const WithSubNav: Story = {
     <>
       <Header {...args} />
       <SubNav
-        variant="dark"
+        theme="dark"
         label="features"
         items={[
           { id: '1', label: 'UI Tests', href: '/ui-tests' },

--- a/src/SubNav/SubNav.stories.tsx
+++ b/src/SubNav/SubNav.stories.tsx
@@ -30,7 +30,7 @@ export const Light: Story = {
 export const Dark: Story = {
   args: {
     ...Light.args,
-    variant: 'dark',
+    theme: 'dark',
   },
   parameters: {
     backgrounds: { default: 'dark' },

--- a/src/SubNav/SubNav.tsx
+++ b/src/SubNav/SubNav.tsx
@@ -10,9 +10,9 @@ import { NavDropdownMenu } from '../NavDropdownMenu';
 
 const Wrapper = styled.div<{ variant?: 'light' | 'dark' }>`
   box-shadow: ${(props) =>
-        props.variant === 'dark' ? color.whiteTr05 : color.blackTr10}
+        props.variant === 'dark' ? color.whiteTr10 : color.blackTr10}
       0 -1px 0px 0px inset,
-    ${(props) => (props.variant === 'dark' ? color.whiteTr05 : color.blackTr10)}
+    ${(props) => (props.variant === 'dark' ? color.whiteTr10 : color.blackTr10)}
       0 1px 0px 0px inset;
 `;
 
@@ -86,7 +86,7 @@ interface SubNavItem {
 }
 
 export interface SubNavProps {
-  variant?: 'light' | 'dark';
+  theme?: 'light' | 'dark';
   label: string;
   items: SubNavItem[];
 }
@@ -94,30 +94,28 @@ export interface SubNavProps {
 export const SubNav: FunctionComponent<SubNavProps> = ({
   label,
   items,
-  variant = 'light',
-}) => {
-  return (
-    <Wrapper variant={variant}>
-      <Container>
-        <DropdownMenuWrapper>
-          <NavDropdownMenu label={label} items={items} variant={variant} />
-        </DropdownMenuWrapper>
-        <TabsMenu gap={0}>
-          {items.map((item) => (
-            <SubNavLink
-              key={item.id}
-              href={item.href}
-              variant={variant}
-              isActive={item.isActive}
-            >
-              {item.label}{' '}
-              {item.external && (
-                <Icon name="sharealt" aria-label="external page" />
-              )}
-            </SubNavLink>
-          ))}
-        </TabsMenu>
-      </Container>
-    </Wrapper>
-  );
-};
+  theme = 'light',
+}) => (
+  <Wrapper variant={theme}>
+    <Container>
+      <DropdownMenuWrapper>
+        <NavDropdownMenu label={label} items={items} variant={theme} />
+      </DropdownMenuWrapper>
+      <TabsMenu gap={0}>
+        {items.map((item) => (
+          <SubNavLink
+            key={item.id}
+            href={item.href}
+            variant={theme}
+            isActive={item.isActive}
+          >
+            {item.label}{' '}
+            {item.external && (
+              <Icon name="sharealt" aria-label="external page" />
+            )}
+          </SubNavLink>
+        ))}
+      </TabsMenu>
+    </Container>
+  </Wrapper>
+);

--- a/src/Testimonial/Testimonial.stories.tsx
+++ b/src/Testimonial/Testimonial.stories.tsx
@@ -33,7 +33,7 @@ export const Base: Story = {
 export const Inverse: Story = {
   args: {
     ...Base.args,
-    inverse: true,
+    theme: 'dark',
     logo: './airbnb.svg',
   },
   parameters: {

--- a/src/Testimonial/Testimonial.tsx
+++ b/src/Testimonial/Testimonial.tsx
@@ -159,7 +159,6 @@ interface TestimonialProps {
   variant?: TestimonialVariant;
   inverse?: boolean;
   companyName?: string;
-  compact: boolean;
 }
 
 export const Testimonial = ({
@@ -171,7 +170,6 @@ export const Testimonial = ({
   jobTitle,
   logo,
   companyName,
-  compact,
   ...props
 }: TestimonialProps) => (
   <div {...props}>
@@ -182,7 +180,7 @@ export const Testimonial = ({
       <Cite>
         <Author>
           <Avatar
-            size={compact ? 'medium' : 'large'}
+            size={variant === 'compact' ? 'medium' : 'large'}
             username={name}
             src={avatarUrl}
           />

--- a/src/Testimonial/Testimonial.tsx
+++ b/src/Testimonial/Testimonial.tsx
@@ -157,13 +157,13 @@ interface TestimonialProps {
   jobTitle: string;
   logo: string;
   variant?: TestimonialVariant;
-  inverse?: boolean;
+  theme?: 'light' | 'dark';
   companyName?: string;
 }
 
 export const Testimonial = ({
   variant = 'default',
-  inverse,
+  theme = 'light',
   text,
   avatarUrl,
   name,
@@ -171,30 +171,33 @@ export const Testimonial = ({
   logo,
   companyName,
   ...props
-}: TestimonialProps) => (
-  <div {...props}>
-    <Inner variant={variant} inverse={inverse}>
-      <Quote variant={variant} inverse={inverse}>
-        {text}
-      </Quote>
-      <Cite>
-        <Author>
-          <Avatar
-            size={variant === 'compact' ? 'medium' : 'large'}
-            username={name}
-            src={avatarUrl}
-          />
-          <Meta>
-            <Name variant={variant} inverse={inverse}>
-              {name}
-            </Name>
-            <JobTitle variant={variant}>{jobTitle}</JobTitle>
-          </Meta>
-        </Author>
-        <Logo variant={variant} inverse={inverse}>
-          <img src={logo} alt={companyName} loading="lazy" />
-        </Logo>
-      </Cite>
-    </Inner>
-  </div>
-);
+}: TestimonialProps) => {
+  const inverse = theme === 'dark';
+  return (
+    <div {...props}>
+      <Inner variant={variant} inverse={inverse}>
+        <Quote variant={variant} inverse={inverse}>
+          {text}
+        </Quote>
+        <Cite>
+          <Author>
+            <Avatar
+              size={variant === 'compact' ? 'medium' : 'large'}
+              username={name}
+              src={avatarUrl}
+            />
+            <Meta>
+              <Name variant={variant} inverse={inverse}>
+                {name}
+              </Name>
+              <JobTitle variant={variant}>{jobTitle}</JobTitle>
+            </Meta>
+          </Author>
+          <Logo variant={variant} inverse={inverse}>
+            <img src={logo} alt={companyName} loading="lazy" />
+          </Logo>
+        </Cite>
+      </Inner>
+    </div>
+  );
+};


### PR DESCRIPTION
I had switched to variants but, missed the compact prop which was being used by avatar. I've removed it and using variant to change avatar size too.

For some components I was using variant for light and dark modes. Swapping that out with themes to stay consistent. 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.14.1--canary.62.8883e19.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/tetra@1.14.1--canary.62.8883e19.0
  # or 
  yarn add @chromaui/tetra@1.14.1--canary.62.8883e19.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
