### PR TITLE
Link: use regular font-weight and add hover animation

### DIFF
--- a/src/Header/Header.stories.tsx
+++ b/src/Header/Header.stories.tsx
@@ -28,7 +28,9 @@ export const DesktopLight: Story = {
     desktopBreakpoint: 992,
     desktopRight: (
       <>
-        <Link href="/">Sign in</Link>
+        <Link emphasis href="/">
+          Sign in
+        </Link>
         <Button size="sm" variant="outline" color="blue">
           Sign up
         </Button>

--- a/src/Link/Link.stories.tsx
+++ b/src/Link/Link.stories.tsx
@@ -23,6 +23,13 @@ export const Base: Story = {
   },
 };
 
+export const Emphasis: Story = {
+  args: {
+    ...Base.args,
+    emphasis: true,
+  },
+};
+
 export const Sizes: Story = {
   args: {
     ...Base.args,

--- a/src/Link/Link.tsx
+++ b/src/Link/Link.tsx
@@ -1,6 +1,6 @@
 import React, { FC, forwardRef } from 'react';
 import { styled } from '@storybook/theming';
-import { color as tokenColor, fontFamily } from '../_tokens';
+import { color as tokenColor, fontFamily, fontWeight } from '../_tokens';
 import { Icon } from '../Icon';
 import type { Icons } from '../Icon/Icon';
 
@@ -15,11 +15,13 @@ export interface LinkProps {
   rel?: string;
   onClick?: () => void;
   as?: 'button' | 'a';
+  emphasis?: boolean;
 }
 
 const Container = styled.a<{
   size: LinkProps['size'];
   color: LinkProps['color'];
+  emphasis: LinkProps['emphasis'];
 }>`
   border: 0;
   border-radius: 3em;
@@ -38,11 +40,21 @@ const Container = styled.a<{
     if (size === 'lg') return '1rem';
     return null;
   }};
-  font-weight: 600;
+  font-weight: ${(props) =>
+    props.emphasis ? fontWeight.semibold : fontWeight.regular};
   font-family: ${fontFamily.sans};
   gap: 0.75rem;
   transition: all 0.16s ease-in-out;
   text-decoration: none;
+
+  &:hover,
+  &:focus-visible {
+    cursor: pointer;
+    transform: translateY(-1px);
+  }
+  &:active {
+    transform: translateY(0);
+  }
 `;
 
 export const Link = forwardRef<
@@ -61,6 +73,7 @@ export const Link = forwardRef<
       rel,
       onClick,
       as,
+      emphasis,
       ...rest
     },
     ref
@@ -75,6 +88,7 @@ export const Link = forwardRef<
 
     return (
       <Container
+        emphasis={emphasis}
         size={size}
         color={color}
         onClick={onClick}


### PR DESCRIPTION
Updates Link component to match styling from SDS
* Use font-weight regular
* Hover and click transitions
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.15.4--canary.68.1a8eee5.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/tetra@1.15.4--canary.68.1a8eee5.0
  # or 
  yarn add @chromaui/tetra@1.15.4--canary.68.1a8eee5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
