### PR TITLE
🪗 Adds Accordion component

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "react-dom": ">=17"
   },
   "dependencies": {
+    "@radix-ui/react-accordion": "1.1.2",
     "@radix-ui/react-collapsible": "1.0.2",
     "@radix-ui/react-dropdown-menu": "2.0.5",
     "@radix-ui/react-navigation-menu": "1.1.2",

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -66,18 +66,16 @@ export const Base: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={0} marginX={0} gap={2}>
-        <Accordion>
-          <Accordion.Item id="1">
-            <Accordion.Trigger iconName={args.iconName}>
-              {args.triggerCopy}
-            </Accordion.Trigger>
-            <Accordion.Panel>
-              <ExamplePanelContent inverse={args.inverse} />
-            </Accordion.Panel>
-          </Accordion.Item>
-        </Accordion>
-      </Stack>
+      <Accordion>
+        <Accordion.Item id="1">
+          <Accordion.Trigger iconName={args.iconName}>
+            {args.triggerCopy}
+          </Accordion.Trigger>
+          <Accordion.Panel>
+            <ExamplePanelContent inverse={args.inverse} />
+          </Accordion.Panel>
+        </Accordion.Item>
+      </Accordion>
     );
   },
 };
@@ -92,18 +90,16 @@ export const Inverse: Story = {
     backgrounds: { default: 'dark' },
   },
   render: (args) => (
-    <Stack direction="column" marginY={0} marginX={0} gap={2}>
-      <Accordion inverse={args.inverse}>
-        <Accordion.Item id="1" inverse={args.inverse}>
-          <Accordion.Trigger iconName={args.iconName} inverse={args.inverse}>
-            {args.triggerCopy}
-          </Accordion.Trigger>
-          <Accordion.Panel inverse={args.inverse}>
-            <ExamplePanelContent inverse={args.inverse} />
-          </Accordion.Panel>
-        </Accordion.Item>
-      </Accordion>
-    </Stack>
+    <Accordion inverse={args.inverse}>
+      <Accordion.Item id="1" inverse={args.inverse}>
+        <Accordion.Trigger iconName={args.iconName} inverse={args.inverse}>
+          {args.triggerCopy}
+        </Accordion.Trigger>
+        <Accordion.Panel inverse={args.inverse}>
+          <ExamplePanelContent inverse={args.inverse} />
+        </Accordion.Panel>
+      </Accordion.Item>
+    </Accordion>
   ),
 };
 
@@ -115,18 +111,16 @@ export const StartingOpen: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={0} marginX={0} gap={2}>
-        <Accordion defaultValue="1">
-          <Accordion.Item id="1">
-            <Accordion.Trigger iconName={args.iconName}>
-              {args.triggerCopy}
-            </Accordion.Trigger>
-            <Accordion.Panel>
-              <ExamplePanelContent inverse={args.inverse} />
-            </Accordion.Panel>
-          </Accordion.Item>
-        </Accordion>
-      </Stack>
+      <Accordion defaultValue="1">
+        <Accordion.Item id="1">
+          <Accordion.Trigger iconName={args.iconName}>
+            {args.triggerCopy}
+          </Accordion.Trigger>
+          <Accordion.Panel>
+            <ExamplePanelContent inverse={args.inverse} />
+          </Accordion.Panel>
+        </Accordion.Item>
+      </Accordion>
     );
   },
 };
@@ -140,18 +134,16 @@ export const WithAlternateIcon: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={0} marginX={0} gap={2}>
-        <Accordion>
-          <Accordion.Item id="1">
-            <Accordion.Trigger iconName={args.iconName}>
-              {args.triggerCopy}
-            </Accordion.Trigger>
-            <Accordion.Panel>
-              <ExamplePanelContent inverse={args.inverse} />
-            </Accordion.Panel>
-          </Accordion.Item>
-        </Accordion>
-      </Stack>
+      <Accordion>
+        <Accordion.Item id="1">
+          <Accordion.Trigger iconName={args.iconName}>
+            {args.triggerCopy}
+          </Accordion.Trigger>
+          <Accordion.Panel>
+            <ExamplePanelContent inverse={args.inverse} />
+          </Accordion.Panel>
+        </Accordion.Item>
+      </Accordion>
     );
   },
 };
@@ -165,18 +157,16 @@ export const WithNoIcon: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={0} marginX={0} gap={2}>
-        <Accordion>
-          <Accordion.Item id="1">
-            <Accordion.Trigger iconName={args.iconName}>
-              {args.triggerCopy}
-            </Accordion.Trigger>
-            <Accordion.Panel>
-              <ExamplePanelContent inverse={args.inverse} />
-            </Accordion.Panel>
-          </Accordion.Item>
-        </Accordion>
-      </Stack>
+      <Accordion>
+        <Accordion.Item id="1">
+          <Accordion.Trigger iconName={args.iconName}>
+            {args.triggerCopy}
+          </Accordion.Trigger>
+          <Accordion.Panel>
+            <ExamplePanelContent inverse={args.inverse} />
+          </Accordion.Panel>
+        </Accordion.Item>
+      </Accordion>
     );
   },
 };
@@ -189,18 +179,16 @@ export const Reversed: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={0} marginX={0} gap={2}>
-        <Accordion>
-          <Accordion.Item id="1">
-            <Accordion.Panel>
-              <ExamplePanelContent inverse={args.inverse} />
-            </Accordion.Panel>
-            <Accordion.Trigger iconName={args.iconName}>
-              {args.triggerCopy}
-            </Accordion.Trigger>
-          </Accordion.Item>
-        </Accordion>
-      </Stack>
+      <Accordion>
+        <Accordion.Item id="1">
+          <Accordion.Panel>
+            <ExamplePanelContent inverse={args.inverse} />
+          </Accordion.Panel>
+          <Accordion.Trigger iconName={args.iconName}>
+            {args.triggerCopy}
+          </Accordion.Trigger>
+        </Accordion.Item>
+      </Accordion>
     );
   },
 };
@@ -216,18 +204,16 @@ export const ReversedInverse: Story = {
     backgrounds: { default: 'dark' },
   },
   render: (args) => (
-    <Stack direction="column" marginY={0} marginX={0} gap={2}>
-      <Accordion inverse={args.inverse}>
-        <Accordion.Item id="1" inverse={args.inverse}>
-          <Accordion.Panel inverse={args.inverse}>
-            <ExamplePanelContent inverse={args.inverse} />
-          </Accordion.Panel>
-          <Accordion.Trigger iconName={args.iconName} inverse={args.inverse}>
-            {args.triggerCopy}
-          </Accordion.Trigger>
-        </Accordion.Item>
-      </Accordion>
-    </Stack>
+    <Accordion inverse={args.inverse}>
+      <Accordion.Item id="1" inverse={args.inverse}>
+        <Accordion.Panel inverse={args.inverse}>
+          <ExamplePanelContent inverse={args.inverse} />
+        </Accordion.Panel>
+        <Accordion.Trigger iconName={args.iconName} inverse={args.inverse}>
+          {args.triggerCopy}
+        </Accordion.Trigger>
+      </Accordion.Item>
+    </Accordion>
   ),
 };
 
@@ -239,24 +225,22 @@ export const Group: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={0} marginX={0} gap={2}>
-        <Accordion>
-          {accordions.map((acc, i) => {
-            const { id, triggerCopy } = acc;
+      <Accordion>
+        {accordions.map((acc, i) => {
+          const { id, triggerCopy } = acc;
 
-            return (
-              <Accordion.Item key={i} id={`item-${id}`}>
-                <Accordion.Trigger iconName={args.iconName}>
-                  {triggerCopy}
-                </Accordion.Trigger>
-                <Accordion.Panel>
-                  <ExamplePanelContent inverse={args.inverse} />
-                </Accordion.Panel>
-              </Accordion.Item>
-            );
-          })}
-        </Accordion>
-      </Stack>
+          return (
+            <Accordion.Item key={i} id={`item-${id}`}>
+              <Accordion.Trigger iconName={args.iconName}>
+                {triggerCopy}
+              </Accordion.Trigger>
+              <Accordion.Panel>
+                <ExamplePanelContent inverse={args.inverse} />
+              </Accordion.Panel>
+            </Accordion.Item>
+          );
+        })}
+      </Accordion>
     );
   },
 };
@@ -272,27 +256,25 @@ export const GroupInverse: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={0} marginX={0} gap={2}>
-        <Accordion inverse={args.inverse}>
-          {accordions.map((acc, i) => {
-            const { id, triggerCopy } = acc;
+      <Accordion inverse={args.inverse}>
+        {accordions.map((acc, i) => {
+          const { id, triggerCopy } = acc;
 
-            return (
-              <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
-                <Accordion.Trigger
-                  iconName={args.iconName}
-                  inverse={args.inverse}
-                >
-                  {triggerCopy} {`  ${id + 1}`}
-                </Accordion.Trigger>
-                <Accordion.Panel inverse={args.inverse}>
-                  <ExamplePanelContent inverse={args.inverse} />
-                </Accordion.Panel>
-              </Accordion.Item>
-            );
-          })}
-        </Accordion>
-      </Stack>
+          return (
+            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+              <Accordion.Trigger
+                iconName={args.iconName}
+                inverse={args.inverse}
+              >
+                {triggerCopy} {`  ${id + 1}`}
+              </Accordion.Trigger>
+              <Accordion.Panel inverse={args.inverse}>
+                <ExamplePanelContent inverse={args.inverse} />
+              </Accordion.Panel>
+            </Accordion.Item>
+          );
+        })}
+      </Accordion>
     );
   },
 };
@@ -306,27 +288,25 @@ export const GroupOpenStart: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={0} marginX={0} gap={2}>
-        <Accordion defaultValue="item-2" inverse={args.inverse}>
-          {accordions.map((acc, i) => {
-            const { id, triggerCopy } = acc;
+      <Accordion defaultValue="item-2" inverse={args.inverse}>
+        {accordions.map((acc, i) => {
+          const { id, triggerCopy } = acc;
 
-            return (
-              <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
-                <Accordion.Trigger
-                  iconName={args.iconName}
-                  inverse={args.inverse}
-                >
-                  {triggerCopy}
-                </Accordion.Trigger>
-                <Accordion.Panel inverse={args.inverse}>
-                  <ExamplePanelContent inverse={args.inverse} />
-                </Accordion.Panel>
-              </Accordion.Item>
-            );
-          })}
-        </Accordion>
-      </Stack>
+          return (
+            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+              <Accordion.Trigger
+                iconName={args.iconName}
+                inverse={args.inverse}
+              >
+                {triggerCopy}
+              </Accordion.Trigger>
+              <Accordion.Panel inverse={args.inverse}>
+                <ExamplePanelContent inverse={args.inverse} />
+              </Accordion.Panel>
+            </Accordion.Item>
+          );
+        })}
+      </Accordion>
     );
   },
 };
@@ -343,27 +323,25 @@ export const GroupOpenStartInverse: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={0} marginX={0} gap={2}>
-        <Accordion defaultValue="item-0" inverse={args.inverse}>
-          {accordions.map((acc, i) => {
-            const { id, triggerCopy } = acc;
+      <Accordion defaultValue="item-0" inverse={args.inverse}>
+        {accordions.map((acc, i) => {
+          const { id, triggerCopy } = acc;
 
-            return (
-              <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
-                <Accordion.Trigger
-                  iconName={args.iconName}
-                  inverse={args.inverse}
-                >
-                  {triggerCopy}
-                </Accordion.Trigger>
-                <Accordion.Panel inverse={args.inverse}>
-                  <ExamplePanelContent inverse={args.inverse} />
-                </Accordion.Panel>
-              </Accordion.Item>
-            );
-          })}
-        </Accordion>
-      </Stack>
+          return (
+            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+              <Accordion.Trigger
+                iconName={args.iconName}
+                inverse={args.inverse}
+              >
+                {triggerCopy}
+              </Accordion.Trigger>
+              <Accordion.Panel inverse={args.inverse}>
+                <ExamplePanelContent inverse={args.inverse} />
+              </Accordion.Panel>
+            </Accordion.Item>
+          );
+        })}
+      </Accordion>
     );
   },
 };
@@ -379,27 +357,25 @@ export const GroupReverse: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={0} marginX={0} gap={2}>
-        <Accordion inverse={args.inverse}>
-          {accordions.map((acc, i) => {
-            const { id, triggerCopy } = acc;
+      <Accordion inverse={args.inverse}>
+        {accordions.map((acc, i) => {
+          const { id, triggerCopy } = acc;
 
-            return (
-              <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
-                <Accordion.Panel inverse={args.inverse}>
-                  <ExamplePanelContent inverse={args.inverse} />
-                </Accordion.Panel>
-                <Accordion.Trigger
-                  iconName={args.iconName}
-                  inverse={args.inverse}
-                >
-                  {triggerCopy} {`  ${id + 1}`}
-                </Accordion.Trigger>
-              </Accordion.Item>
-            );
-          })}
-        </Accordion>
-      </Stack>
+          return (
+            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+              <Accordion.Panel inverse={args.inverse}>
+                <ExamplePanelContent inverse={args.inverse} />
+              </Accordion.Panel>
+              <Accordion.Trigger
+                iconName={args.iconName}
+                inverse={args.inverse}
+              >
+                {triggerCopy} {`  ${id + 1}`}
+              </Accordion.Trigger>
+            </Accordion.Item>
+          );
+        })}
+      </Accordion>
     );
   },
 };
@@ -415,24 +391,22 @@ export const GroupWithAlternateIcons: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={0} marginX={0} gap={2}>
-        <Accordion inverse={args.inverse}>
-          {accordions.map((acc, i) => {
-            const { id, triggerCopy, icon } = acc;
+      <Accordion inverse={args.inverse}>
+        {accordions.map((acc, i) => {
+          const { id, triggerCopy, icon } = acc;
 
-            return (
-              <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
-                <Accordion.Trigger inverse={args.inverse} iconName={icon}>
-                  {triggerCopy}
-                </Accordion.Trigger>
-                <Accordion.Panel inverse={args.inverse}>
-                  <ExamplePanelContent inverse={args.inverse} />
-                </Accordion.Panel>
-              </Accordion.Item>
-            );
-          })}
-        </Accordion>
-      </Stack>
+          return (
+            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+              <Accordion.Trigger inverse={args.inverse} iconName={icon}>
+                {triggerCopy}
+              </Accordion.Trigger>
+              <Accordion.Panel inverse={args.inverse}>
+                <ExamplePanelContent inverse={args.inverse} />
+              </Accordion.Panel>
+            </Accordion.Item>
+          );
+        })}
+      </Accordion>
     );
   },
 };

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -42,7 +42,7 @@ const accordions = [
   },
 ];
 
-const PanelContent = ({ inverse }) => {
+const ExamplePanelContent = ({ inverse }) => {
   const color = inverse ? 'white' : 'slate800';
 
   return (
@@ -73,7 +73,7 @@ export const Base: Story = {
               {args.triggerCopy}
             </Accordion.Trigger>
             <Accordion.Panel>
-              <PanelContent inverse={args.inverse} />
+              <ExamplePanelContent inverse={args.inverse} />
             </Accordion.Panel>
           </Accordion.Item>
         </Accordion>
@@ -99,7 +99,7 @@ export const Inverse: Story = {
             {args.triggerCopy}
           </Accordion.Trigger>
           <Accordion.Panel inverse={args.inverse}>
-            <PanelContent inverse={args.inverse} />
+            <ExamplePanelContent inverse={args.inverse} />
           </Accordion.Panel>
         </Accordion.Item>
       </Accordion>
@@ -122,7 +122,7 @@ export const StartingOpen: Story = {
               {args.triggerCopy}
             </Accordion.Trigger>
             <Accordion.Panel>
-              <PanelContent inverse={args.inverse} />
+              <ExamplePanelContent inverse={args.inverse} />
             </Accordion.Panel>
           </Accordion.Item>
         </Accordion>
@@ -147,7 +147,7 @@ export const WithAlternateIcon: Story = {
               {args.triggerCopy}
             </Accordion.Trigger>
             <Accordion.Panel>
-              <PanelContent inverse={args.inverse} />
+              <ExamplePanelContent inverse={args.inverse} />
             </Accordion.Panel>
           </Accordion.Item>
         </Accordion>
@@ -172,7 +172,7 @@ export const WithNoIcon: Story = {
               {args.triggerCopy}
             </Accordion.Trigger>
             <Accordion.Panel>
-              <PanelContent inverse={args.inverse} />
+              <ExamplePanelContent inverse={args.inverse} />
             </Accordion.Panel>
           </Accordion.Item>
         </Accordion>
@@ -193,7 +193,7 @@ export const Reversed: Story = {
         <Accordion>
           <Accordion.Item id="1">
             <Accordion.Panel>
-              <PanelContent inverse={args.inverse} />
+              <ExamplePanelContent inverse={args.inverse} />
             </Accordion.Panel>
             <Accordion.Trigger iconName={args.iconName}>
               {args.triggerCopy}
@@ -220,7 +220,7 @@ export const ReversedInverse: Story = {
       <Accordion inverse={args.inverse}>
         <Accordion.Item id="1" inverse={args.inverse}>
           <Accordion.Panel inverse={args.inverse}>
-            <PanelContent inverse={args.inverse} />
+            <ExamplePanelContent inverse={args.inverse} />
           </Accordion.Panel>
           <Accordion.Trigger iconName={args.iconName} inverse={args.inverse}>
             {args.triggerCopy}
@@ -250,7 +250,7 @@ export const Group: Story = {
                   {triggerCopy}
                 </Accordion.Trigger>
                 <Accordion.Panel>
-                  <PanelContent inverse={args.inverse} />
+                  <ExamplePanelContent inverse={args.inverse} />
                 </Accordion.Panel>
               </Accordion.Item>
             );
@@ -286,7 +286,7 @@ export const GroupInverse: Story = {
                   {triggerCopy} {`  ${id + 1}`}
                 </Accordion.Trigger>
                 <Accordion.Panel inverse={args.inverse}>
-                  <PanelContent inverse={args.inverse} />
+                  <ExamplePanelContent inverse={args.inverse} />
                 </Accordion.Panel>
               </Accordion.Item>
             );
@@ -320,7 +320,7 @@ export const GroupOpenStart: Story = {
                   {triggerCopy}
                 </Accordion.Trigger>
                 <Accordion.Panel inverse={args.inverse}>
-                  <PanelContent inverse={args.inverse} />
+                  <ExamplePanelContent inverse={args.inverse} />
                 </Accordion.Panel>
               </Accordion.Item>
             );
@@ -357,7 +357,7 @@ export const GroupOpenStartInverse: Story = {
                   {triggerCopy}
                 </Accordion.Trigger>
                 <Accordion.Panel inverse={args.inverse}>
-                  <PanelContent inverse={args.inverse} />
+                  <ExamplePanelContent inverse={args.inverse} />
                 </Accordion.Panel>
               </Accordion.Item>
             );
@@ -387,7 +387,7 @@ export const GroupReverse: Story = {
             return (
               <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
                 <Accordion.Panel inverse={args.inverse}>
-                  <PanelContent inverse={args.inverse} />
+                  <ExamplePanelContent inverse={args.inverse} />
                 </Accordion.Panel>
                 <Accordion.Trigger
                   iconName={args.iconName}
@@ -426,7 +426,7 @@ export const GroupWithAlternateIcons: Story = {
                   {triggerCopy}
                 </Accordion.Trigger>
                 <Accordion.Panel inverse={args.inverse}>
-                  <PanelContent inverse={args.inverse} />
+                  <ExamplePanelContent inverse={args.inverse} />
                 </Accordion.Panel>
               </Accordion.Item>
             );

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -1,0 +1,399 @@
+import { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { Stack } from '../Stack';
+import { Text } from '../Text';
+import { Placeholder } from '../_localComponents/Placeholder';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionPanel,
+} from './Accordion';
+
+const meta: Meta<typeof Accordion> = {
+  title: 'Components/Accordion',
+  component: Accordion,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Accordion>;
+
+const PanelContent = () => (
+  <Text>
+    Lorem, ipsum dolor sit amet consectetur adipisicing elit. Quae, autem
+    expedita, in explicabo inventore quasi enim iusto voluptate quibusdam eius,
+    quas corporis. Aperiam vel minima nulla sint animi in ducimus.
+  </Text>
+);
+
+export const Base: Story = {
+  args: {
+    inverse: false,
+    iconName: 'arrowdown',
+    iconSize: 14,
+    triggerCopy: 'Accordion trigger',
+  },
+  parameters: {
+    backgrounds: { default: 'light' },
+  },
+  render: (args) => {
+    return (
+      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+        <Accordion>
+          <AccordionItem id="1">
+            <AccordionTrigger iconName={args.iconName}>
+              {args.triggerCopy}
+            </AccordionTrigger>
+            <AccordionPanel>
+              <PanelContent />
+            </AccordionPanel>
+          </AccordionItem>
+        </Accordion>
+      </Stack>
+    );
+  },
+};
+
+export const Inverse: Story = {
+  ...Base,
+  args: {
+    ...Base.args,
+    inverse: true,
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  render: (args) => (
+    <Stack direction="column" marginY={10} marginX={10} gap={2}>
+      <Accordion inverse={args.inverse}>
+        <AccordionItem id="1" inverse={args.inverse}>
+          <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
+            {args.triggerCopy}
+          </AccordionTrigger>
+          <AccordionPanel inverse={args.inverse}>
+            <PanelContent />
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    </Stack>
+  ),
+};
+
+export const StartingOpen: Story = {
+  ...Base,
+  args: {
+    ...Base.args,
+    inverse: false,
+  },
+  render: (args) => {
+    return (
+      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+        <Accordion defaultValue="1">
+          <AccordionItem id="1">
+            <AccordionTrigger iconName={args.iconName}>
+              {args.triggerCopy}
+            </AccordionTrigger>
+            <AccordionPanel>
+              <PanelContent />
+            </AccordionPanel>
+          </AccordionItem>
+        </Accordion>
+      </Stack>
+    );
+  },
+};
+
+export const WithAlternateIcon: Story = {
+  ...Base,
+  args: {
+    ...Base.args,
+    iconName: 'heart',
+    inverse: false,
+  },
+  render: (args) => {
+    return (
+      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+        <Accordion>
+          <AccordionItem id="1">
+            <AccordionTrigger iconName={args.iconName}>
+              {args.triggerCopy}
+            </AccordionTrigger>
+            <AccordionPanel>
+              <PanelContent />
+            </AccordionPanel>
+          </AccordionItem>
+        </Accordion>
+      </Stack>
+    );
+  },
+};
+
+export const WithNoIcon: Story = {
+  ...Base,
+  args: {
+    ...Base.args,
+    iconName: false,
+    inverse: false,
+  },
+  render: (args) => {
+    return (
+      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+        <Accordion>
+          <AccordionItem id="1">
+            <AccordionTrigger iconName={args.iconName}>
+              {args.triggerCopy}
+            </AccordionTrigger>
+            <AccordionPanel>
+              <PanelContent />
+            </AccordionPanel>
+          </AccordionItem>
+        </Accordion>
+      </Stack>
+    );
+  },
+};
+
+export const Reversed: Story = {
+  ...Base,
+  args: {
+    ...Base.args,
+    inverse: false,
+  },
+  render: (args) => {
+    return (
+      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+        <Accordion>
+          <AccordionItem id="1">
+            <AccordionPanel>
+              <PanelContent />
+            </AccordionPanel>
+            <AccordionTrigger iconName={args.iconName}>
+              {args.triggerCopy}
+            </AccordionTrigger>
+          </AccordionItem>
+        </Accordion>
+      </Stack>
+    );
+  },
+};
+
+export const ReversedInverse: Story = {
+  ...Base,
+  name: 'Reversed and Inverse',
+  args: {
+    ...Base.args,
+    inverse: true,
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  render: (args) => (
+    <Stack direction="column" marginY={10} marginX={10} gap={2}>
+      <Accordion inverse={args.inverse}>
+        <AccordionItem id="1" inverse={args.inverse}>
+          <AccordionPanel inverse={args.inverse}>
+            <PanelContent />
+          </AccordionPanel>
+          <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
+            {args.triggerCopy}
+          </AccordionTrigger>
+        </AccordionItem>
+      </Accordion>
+    </Stack>
+  ),
+};
+
+export const Group: Story = {
+  ...Base,
+  args: {
+    ...Base.args,
+    inverse: false,
+  },
+  render: (args) => {
+    const accordionIds = [0, 1, 2, 3];
+
+    return (
+      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+        <Accordion>
+          {accordionIds.map((id, i) => (
+            <AccordionItem key={i} id={`item-${id}`}>
+              <AccordionTrigger iconName={args.iconName}>
+                {args.triggerCopy} {`  ${id + 1}`}
+              </AccordionTrigger>
+              <AccordionPanel>
+                <PanelContent />
+              </AccordionPanel>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </Stack>
+    );
+  },
+};
+
+export const GroupInverse: Story = {
+  ...Base,
+  args: {
+    ...Base.args,
+    inverse: true,
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  render: (args) => {
+    const accordionIds = [0, 1, 2, 3];
+
+    return (
+      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+        <Accordion inverse={args.inverse}>
+          {accordionIds.map((id, i) => (
+            <AccordionItem inverse={args.inverse} key={i} id={`item-${id}`}>
+              <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
+                {args.triggerCopy} {`  ${id + 1}`}
+              </AccordionTrigger>
+              <AccordionPanel inverse={args.inverse}>
+                <PanelContent />
+              </AccordionPanel>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </Stack>
+    );
+  },
+};
+
+export const GroupOpenStart: Story = {
+  ...Base,
+  name: 'Group: Starting Open',
+  args: {
+    ...Base.args,
+    inverse: false,
+  },
+  render: (args) => {
+    const accordionIds = [0, 1, 2, 3];
+
+    return (
+      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+        <Accordion defaultValue="item-2" inverse={args.inverse}>
+          {accordionIds.map((id, i) => (
+            <AccordionItem inverse={args.inverse} key={i} id={`item-${id}`}>
+              <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
+                {args.triggerCopy} {`  ${id + 1}`}
+              </AccordionTrigger>
+              <AccordionPanel inverse={args.inverse}>
+                <PanelContent />
+              </AccordionPanel>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </Stack>
+    );
+  },
+};
+
+export const GroupOpenStartInverse: Story = {
+  ...Base,
+  name: 'Group: Starting Open and Inverse',
+  args: {
+    ...Base.args,
+    inverse: true,
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+  },
+  render: (args) => {
+    const accordionIds = [0, 1, 2, 3];
+
+    return (
+      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+        <Accordion defaultValue="item-0" inverse={args.inverse}>
+          {accordionIds.map((id, i) => (
+            <AccordionItem inverse={args.inverse} key={i} id={`item-${id}`}>
+              <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
+                {args.triggerCopy} {`  ${id + 1}`}
+              </AccordionTrigger>
+              <AccordionPanel inverse={args.inverse}>
+                <PanelContent />
+              </AccordionPanel>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </Stack>
+    );
+  },
+};
+
+export const GroupReverse: Story = {
+  ...Base,
+  args: {
+    ...Base.args,
+    inverse: false,
+  },
+  parameters: {
+    backgrounds: { default: 'light' },
+  },
+  render: (args) => {
+    const accordionIds = [0, 1, 2, 3];
+
+    return (
+      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+        <Accordion inverse={args.inverse}>
+          {accordionIds.map((id, i) => (
+            <AccordionItem inverse={args.inverse} key={i} id={`item-${id}`}>
+              <AccordionPanel inverse={args.inverse}>
+                <PanelContent />
+              </AccordionPanel>
+              <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
+                {args.triggerCopy} {`  ${id + 1}`}
+              </AccordionTrigger>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </Stack>
+    );
+  },
+};
+
+export const GroupWithAlternateIcons: Story = {
+  ...Base,
+  args: {
+    ...Base.args,
+    inverse: false,
+  },
+  parameters: {
+    backgrounds: { default: 'light' },
+  },
+  render: (args) => {
+    const accordions = [
+      { id: 0, icon: 'cloudhollow' },
+      { id: 1, icon: 'facehappy' },
+      { id: 2, icon: 'accessibilityalt' },
+      { id: 3, icon: 'heart' },
+    ];
+
+    return (
+      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+        <Accordion inverse={args.inverse}>
+          {accordions.map((acc, i) => {
+            const { id, icon } = acc;
+
+            return (
+              <AccordionItem inverse={args.inverse} key={i} id={`item-${id}`}>
+                <AccordionTrigger inverse={args.inverse} iconName={icon}>
+                  {args.triggerCopy} {`  ${id + 1}`}
+                </AccordionTrigger>
+                <AccordionPanel inverse={args.inverse}>
+                  <PanelContent />
+                </AccordionPanel>
+              </AccordionItem>
+            );
+          })}
+        </Accordion>
+      </Stack>
+    );
+  },
+};

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -22,13 +22,17 @@ const meta: Meta<typeof Accordion> = {
 export default meta;
 type Story = StoryObj<typeof Accordion>;
 
-const PanelContent = () => (
-  <Text>
-    Lorem, ipsum dolor sit amet consectetur adipisicing elit. Quae, autem
-    expedita, in explicabo inventore quasi enim iusto voluptate quibusdam eius,
-    quas corporis. Aperiam vel minima nulla sint animi in ducimus.
-  </Text>
-);
+const PanelContent = ({ inverse }) => {
+  const color = inverse ? 'white' : 'slate800';
+
+  return (
+    <Text color={color}>
+      Lorem, ipsum dolor sit amet consectetur adipisicing elit. Quae, autem
+      expedita, in explicabo inventore quasi enim iusto voluptate quibusdam
+      eius, quas corporis. Aperiam vel minima nulla sint animi in ducimus.
+    </Text>
+  );
+};
 
 export const Base: Story = {
   args: {
@@ -49,7 +53,7 @@ export const Base: Story = {
               {args.triggerCopy}
             </AccordionTrigger>
             <AccordionPanel>
-              <PanelContent />
+              <PanelContent inverse={args.inverse} />
             </AccordionPanel>
           </AccordionItem>
         </Accordion>
@@ -75,7 +79,7 @@ export const Inverse: Story = {
             {args.triggerCopy}
           </AccordionTrigger>
           <AccordionPanel inverse={args.inverse}>
-            <PanelContent />
+            <PanelContent inverse={args.inverse} />
           </AccordionPanel>
         </AccordionItem>
       </Accordion>
@@ -98,7 +102,7 @@ export const StartingOpen: Story = {
               {args.triggerCopy}
             </AccordionTrigger>
             <AccordionPanel>
-              <PanelContent />
+              <PanelContent inverse={args.inverse} />
             </AccordionPanel>
           </AccordionItem>
         </Accordion>
@@ -123,7 +127,7 @@ export const WithAlternateIcon: Story = {
               {args.triggerCopy}
             </AccordionTrigger>
             <AccordionPanel>
-              <PanelContent />
+              <PanelContent inverse={args.inverse} />
             </AccordionPanel>
           </AccordionItem>
         </Accordion>
@@ -148,7 +152,7 @@ export const WithNoIcon: Story = {
               {args.triggerCopy}
             </AccordionTrigger>
             <AccordionPanel>
-              <PanelContent />
+              <PanelContent inverse={args.inverse} />
             </AccordionPanel>
           </AccordionItem>
         </Accordion>
@@ -169,7 +173,7 @@ export const Reversed: Story = {
         <Accordion>
           <AccordionItem id="1">
             <AccordionPanel>
-              <PanelContent />
+              <PanelContent inverse={args.inverse} />
             </AccordionPanel>
             <AccordionTrigger iconName={args.iconName}>
               {args.triggerCopy}
@@ -196,7 +200,7 @@ export const ReversedInverse: Story = {
       <Accordion inverse={args.inverse}>
         <AccordionItem id="1" inverse={args.inverse}>
           <AccordionPanel inverse={args.inverse}>
-            <PanelContent />
+            <PanelContent inverse={args.inverse} />
           </AccordionPanel>
           <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
             {args.triggerCopy}
@@ -225,7 +229,7 @@ export const Group: Story = {
                 {args.triggerCopy} {`  ${id + 1}`}
               </AccordionTrigger>
               <AccordionPanel>
-                <PanelContent />
+                <PanelContent inverse={args.inverse} />
               </AccordionPanel>
             </AccordionItem>
           ))}
@@ -256,7 +260,7 @@ export const GroupInverse: Story = {
                 {args.triggerCopy} {`  ${id + 1}`}
               </AccordionTrigger>
               <AccordionPanel inverse={args.inverse}>
-                <PanelContent />
+                <PanelContent inverse={args.inverse} />
               </AccordionPanel>
             </AccordionItem>
           ))}
@@ -285,7 +289,7 @@ export const GroupOpenStart: Story = {
                 {args.triggerCopy} {`  ${id + 1}`}
               </AccordionTrigger>
               <AccordionPanel inverse={args.inverse}>
-                <PanelContent />
+                <PanelContent inverse={args.inverse} />
               </AccordionPanel>
             </AccordionItem>
           ))}
@@ -317,7 +321,7 @@ export const GroupOpenStartInverse: Story = {
                 {args.triggerCopy} {`  ${id + 1}`}
               </AccordionTrigger>
               <AccordionPanel inverse={args.inverse}>
-                <PanelContent />
+                <PanelContent inverse={args.inverse} />
               </AccordionPanel>
             </AccordionItem>
           ))}
@@ -345,7 +349,7 @@ export const GroupReverse: Story = {
           {accordionIds.map((id, i) => (
             <AccordionItem inverse={args.inverse} key={i} id={`item-${id}`}>
               <AccordionPanel inverse={args.inverse}>
-                <PanelContent />
+                <PanelContent inverse={args.inverse} />
               </AccordionPanel>
               <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
                 {args.triggerCopy} {`  ${id + 1}`}
@@ -387,7 +391,7 @@ export const GroupWithAlternateIcons: Story = {
                   {args.triggerCopy} {`  ${id + 1}`}
                 </AccordionTrigger>
                 <AccordionPanel inverse={args.inverse}>
-                  <PanelContent />
+                  <PanelContent inverse={args.inverse} />
                 </AccordionPanel>
               </AccordionItem>
             );

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -17,6 +17,25 @@ const meta: Meta<typeof Accordion> = {
 export default meta;
 type Story = StoryObj<typeof Accordion>;
 
+const accordions = [
+  {
+    id: 0,
+    triggerCopy: 'Does Chromatic replace Jest or Enzyme?',
+    icon: 'cloudhollow',
+  },
+  {
+    id: 1,
+    triggerCopy: 'Can I get rid of my BrowserStack or Sauce subscription?',
+    icon: 'facehappy',
+  },
+  {
+    id: 2,
+    triggerCopy: 'How is this compared to Selenium, Cypress, or Playwright?',
+    icon: 'accessibilityalt',
+  },
+  { id: 3, triggerCopy: 'Why run visual tests in the cloud?', icon: 'heart' },
+];
+
 const PanelContent = ({ inverse }) => {
   const color = inverse ? 'white' : 'slate800';
 
@@ -34,7 +53,7 @@ export const Base: Story = {
     inverse: false,
     iconName: 'arrowdown',
     iconSize: 14,
-    triggerCopy: 'Accordion trigger',
+    triggerCopy: 'How is this compared to Selenium, Cypress, or Playwright?',
   },
   parameters: {
     backgrounds: { default: 'light' },
@@ -213,21 +232,23 @@ export const Group: Story = {
     inverse: false,
   },
   render: (args) => {
-    const accordionIds = [0, 1, 2, 3];
-
     return (
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion>
-          {accordionIds.map((id, i) => (
-            <Accordion.Item key={i} id={`item-${id}`}>
-              <Accordion.Trigger iconName={args.iconName}>
-                {args.triggerCopy} {`  ${id + 1}`}
-              </Accordion.Trigger>
-              <Accordion.Panel>
-                <PanelContent inverse={args.inverse} />
-              </Accordion.Panel>
-            </Accordion.Item>
-          ))}
+          {accordions.map((acc, i) => {
+            const { id, triggerCopy } = acc;
+
+            return (
+              <Accordion.Item key={i} id={`item-${id}`}>
+                <Accordion.Trigger iconName={args.iconName}>
+                  {triggerCopy}
+                </Accordion.Trigger>
+                <Accordion.Panel>
+                  <PanelContent inverse={args.inverse} />
+                </Accordion.Panel>
+              </Accordion.Item>
+            );
+          })}
         </Accordion>
       </Stack>
     );
@@ -244,24 +265,26 @@ export const GroupInverse: Story = {
     backgrounds: { default: 'dark' },
   },
   render: (args) => {
-    const accordionIds = [0, 1, 2, 3];
-
     return (
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion inverse={args.inverse}>
-          {accordionIds.map((id, i) => (
-            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
-              <Accordion.Trigger
-                iconName={args.iconName}
-                inverse={args.inverse}
-              >
-                {args.triggerCopy} {`  ${id + 1}`}
-              </Accordion.Trigger>
-              <Accordion.Panel inverse={args.inverse}>
-                <PanelContent inverse={args.inverse} />
-              </Accordion.Panel>
-            </Accordion.Item>
-          ))}
+          {accordions.map((acc, i) => {
+            const { id, triggerCopy } = acc;
+
+            return (
+              <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+                <Accordion.Trigger
+                  iconName={args.iconName}
+                  inverse={args.inverse}
+                >
+                  {triggerCopy} {`  ${id + 1}`}
+                </Accordion.Trigger>
+                <Accordion.Panel inverse={args.inverse}>
+                  <PanelContent inverse={args.inverse} />
+                </Accordion.Panel>
+              </Accordion.Item>
+            );
+          })}
         </Accordion>
       </Stack>
     );
@@ -276,24 +299,26 @@ export const GroupOpenStart: Story = {
     inverse: false,
   },
   render: (args) => {
-    const accordionIds = [0, 1, 2, 3];
-
     return (
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion defaultValue="item-2" inverse={args.inverse}>
-          {accordionIds.map((id, i) => (
-            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
-              <Accordion.Trigger
-                iconName={args.iconName}
-                inverse={args.inverse}
-              >
-                {args.triggerCopy} {`  ${id + 1}`}
-              </Accordion.Trigger>
-              <Accordion.Panel inverse={args.inverse}>
-                <PanelContent inverse={args.inverse} />
-              </Accordion.Panel>
-            </Accordion.Item>
-          ))}
+          {accordions.map((acc, i) => {
+            const { id, triggerCopy } = acc;
+
+            return (
+              <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+                <Accordion.Trigger
+                  iconName={args.iconName}
+                  inverse={args.inverse}
+                >
+                  {triggerCopy}
+                </Accordion.Trigger>
+                <Accordion.Panel inverse={args.inverse}>
+                  <PanelContent inverse={args.inverse} />
+                </Accordion.Panel>
+              </Accordion.Item>
+            );
+          })}
         </Accordion>
       </Stack>
     );
@@ -311,24 +336,26 @@ export const GroupOpenStartInverse: Story = {
     backgrounds: { default: 'dark' },
   },
   render: (args) => {
-    const accordionIds = [0, 1, 2, 3];
-
     return (
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion defaultValue="item-0" inverse={args.inverse}>
-          {accordionIds.map((id, i) => (
-            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
-              <Accordion.Trigger
-                iconName={args.iconName}
-                inverse={args.inverse}
-              >
-                {args.triggerCopy} {`  ${id + 1}`}
-              </Accordion.Trigger>
-              <Accordion.Panel inverse={args.inverse}>
-                <PanelContent inverse={args.inverse} />
-              </Accordion.Panel>
-            </Accordion.Item>
-          ))}
+          {accordions.map((acc, i) => {
+            const { id, triggerCopy } = acc;
+
+            return (
+              <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+                <Accordion.Trigger
+                  iconName={args.iconName}
+                  inverse={args.inverse}
+                >
+                  {triggerCopy}
+                </Accordion.Trigger>
+                <Accordion.Panel inverse={args.inverse}>
+                  <PanelContent inverse={args.inverse} />
+                </Accordion.Panel>
+              </Accordion.Item>
+            );
+          })}
         </Accordion>
       </Stack>
     );
@@ -345,24 +372,26 @@ export const GroupReverse: Story = {
     backgrounds: { default: 'light' },
   },
   render: (args) => {
-    const accordionIds = [0, 1, 2, 3];
-
     return (
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion inverse={args.inverse}>
-          {accordionIds.map((id, i) => (
-            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
-              <Accordion.Panel inverse={args.inverse}>
-                <PanelContent inverse={args.inverse} />
-              </Accordion.Panel>
-              <Accordion.Trigger
-                iconName={args.iconName}
-                inverse={args.inverse}
-              >
-                {args.triggerCopy} {`  ${id + 1}`}
-              </Accordion.Trigger>
-            </Accordion.Item>
-          ))}
+          {accordions.map((acc, i) => {
+            const { id, triggerCopy } = acc;
+
+            return (
+              <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+                <Accordion.Panel inverse={args.inverse}>
+                  <PanelContent inverse={args.inverse} />
+                </Accordion.Panel>
+                <Accordion.Trigger
+                  iconName={args.iconName}
+                  inverse={args.inverse}
+                >
+                  {triggerCopy} {`  ${id + 1}`}
+                </Accordion.Trigger>
+              </Accordion.Item>
+            );
+          })}
         </Accordion>
       </Stack>
     );
@@ -379,23 +408,16 @@ export const GroupWithAlternateIcons: Story = {
     backgrounds: { default: 'light' },
   },
   render: (args) => {
-    const accordions = [
-      { id: 0, icon: 'cloudhollow' },
-      { id: 1, icon: 'facehappy' },
-      { id: 2, icon: 'accessibilityalt' },
-      { id: 3, icon: 'heart' },
-    ];
-
     return (
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion inverse={args.inverse}>
           {accordions.map((acc, i) => {
-            const { id, icon } = acc;
+            const { id, triggerCopy, icon } = acc;
 
             return (
               <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
                 <Accordion.Trigger inverse={args.inverse} iconName={icon}>
-                  {args.triggerCopy} {`  ${id + 1}`}
+                  {triggerCopy}
                 </Accordion.Trigger>
                 <Accordion.Panel inverse={args.inverse}>
                   <PanelContent inverse={args.inverse} />

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -3,12 +3,7 @@ import React from 'react';
 import { Stack } from '../Stack';
 import { Text } from '../Text';
 import { Placeholder } from '../_localComponents/Placeholder';
-import {
-  Accordion,
-  AccordionItem,
-  AccordionTrigger,
-  AccordionPanel,
-} from './Accordion';
+import { Accordion } from './Accordion';
 
 const meta: Meta<typeof Accordion> = {
   title: 'Components/Accordion',
@@ -48,14 +43,14 @@ export const Base: Story = {
     return (
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion>
-          <AccordionItem id="1">
-            <AccordionTrigger iconName={args.iconName}>
+          <Accordion.Item id="1">
+            <Accordion.Trigger iconName={args.iconName}>
               {args.triggerCopy}
-            </AccordionTrigger>
-            <AccordionPanel>
+            </Accordion.Trigger>
+            <Accordion.Panel>
               <PanelContent inverse={args.inverse} />
-            </AccordionPanel>
-          </AccordionItem>
+            </Accordion.Panel>
+          </Accordion.Item>
         </Accordion>
       </Stack>
     );
@@ -74,14 +69,14 @@ export const Inverse: Story = {
   render: (args) => (
     <Stack direction="column" marginY={10} marginX={10} gap={2}>
       <Accordion inverse={args.inverse}>
-        <AccordionItem id="1" inverse={args.inverse}>
-          <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
+        <Accordion.Item id="1" inverse={args.inverse}>
+          <Accordion.Trigger iconName={args.iconName} inverse={args.inverse}>
             {args.triggerCopy}
-          </AccordionTrigger>
-          <AccordionPanel inverse={args.inverse}>
+          </Accordion.Trigger>
+          <Accordion.Panel inverse={args.inverse}>
             <PanelContent inverse={args.inverse} />
-          </AccordionPanel>
-        </AccordionItem>
+          </Accordion.Panel>
+        </Accordion.Item>
       </Accordion>
     </Stack>
   ),
@@ -97,14 +92,14 @@ export const StartingOpen: Story = {
     return (
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion defaultValue="1">
-          <AccordionItem id="1">
-            <AccordionTrigger iconName={args.iconName}>
+          <Accordion.Item id="1">
+            <Accordion.Trigger iconName={args.iconName}>
               {args.triggerCopy}
-            </AccordionTrigger>
-            <AccordionPanel>
+            </Accordion.Trigger>
+            <Accordion.Panel>
               <PanelContent inverse={args.inverse} />
-            </AccordionPanel>
-          </AccordionItem>
+            </Accordion.Panel>
+          </Accordion.Item>
         </Accordion>
       </Stack>
     );
@@ -122,14 +117,14 @@ export const WithAlternateIcon: Story = {
     return (
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion>
-          <AccordionItem id="1">
-            <AccordionTrigger iconName={args.iconName}>
+          <Accordion.Item id="1">
+            <Accordion.Trigger iconName={args.iconName}>
               {args.triggerCopy}
-            </AccordionTrigger>
-            <AccordionPanel>
+            </Accordion.Trigger>
+            <Accordion.Panel>
               <PanelContent inverse={args.inverse} />
-            </AccordionPanel>
-          </AccordionItem>
+            </Accordion.Panel>
+          </Accordion.Item>
         </Accordion>
       </Stack>
     );
@@ -147,14 +142,14 @@ export const WithNoIcon: Story = {
     return (
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion>
-          <AccordionItem id="1">
-            <AccordionTrigger iconName={args.iconName}>
+          <Accordion.Item id="1">
+            <Accordion.Trigger iconName={args.iconName}>
               {args.triggerCopy}
-            </AccordionTrigger>
-            <AccordionPanel>
+            </Accordion.Trigger>
+            <Accordion.Panel>
               <PanelContent inverse={args.inverse} />
-            </AccordionPanel>
-          </AccordionItem>
+            </Accordion.Panel>
+          </Accordion.Item>
         </Accordion>
       </Stack>
     );
@@ -171,14 +166,14 @@ export const Reversed: Story = {
     return (
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion>
-          <AccordionItem id="1">
-            <AccordionPanel>
+          <Accordion.Item id="1">
+            <Accordion.Panel>
               <PanelContent inverse={args.inverse} />
-            </AccordionPanel>
-            <AccordionTrigger iconName={args.iconName}>
+            </Accordion.Panel>
+            <Accordion.Trigger iconName={args.iconName}>
               {args.triggerCopy}
-            </AccordionTrigger>
-          </AccordionItem>
+            </Accordion.Trigger>
+          </Accordion.Item>
         </Accordion>
       </Stack>
     );
@@ -198,14 +193,14 @@ export const ReversedInverse: Story = {
   render: (args) => (
     <Stack direction="column" marginY={10} marginX={10} gap={2}>
       <Accordion inverse={args.inverse}>
-        <AccordionItem id="1" inverse={args.inverse}>
-          <AccordionPanel inverse={args.inverse}>
+        <Accordion.Item id="1" inverse={args.inverse}>
+          <Accordion.Panel inverse={args.inverse}>
             <PanelContent inverse={args.inverse} />
-          </AccordionPanel>
-          <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
+          </Accordion.Panel>
+          <Accordion.Trigger iconName={args.iconName} inverse={args.inverse}>
             {args.triggerCopy}
-          </AccordionTrigger>
-        </AccordionItem>
+          </Accordion.Trigger>
+        </Accordion.Item>
       </Accordion>
     </Stack>
   ),
@@ -224,14 +219,14 @@ export const Group: Story = {
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion>
           {accordionIds.map((id, i) => (
-            <AccordionItem key={i} id={`item-${id}`}>
-              <AccordionTrigger iconName={args.iconName}>
+            <Accordion.Item key={i} id={`item-${id}`}>
+              <Accordion.Trigger iconName={args.iconName}>
                 {args.triggerCopy} {`  ${id + 1}`}
-              </AccordionTrigger>
-              <AccordionPanel>
+              </Accordion.Trigger>
+              <Accordion.Panel>
                 <PanelContent inverse={args.inverse} />
-              </AccordionPanel>
-            </AccordionItem>
+              </Accordion.Panel>
+            </Accordion.Item>
           ))}
         </Accordion>
       </Stack>
@@ -255,14 +250,17 @@ export const GroupInverse: Story = {
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion inverse={args.inverse}>
           {accordionIds.map((id, i) => (
-            <AccordionItem inverse={args.inverse} key={i} id={`item-${id}`}>
-              <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
+            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+              <Accordion.Trigger
+                iconName={args.iconName}
+                inverse={args.inverse}
+              >
                 {args.triggerCopy} {`  ${id + 1}`}
-              </AccordionTrigger>
-              <AccordionPanel inverse={args.inverse}>
+              </Accordion.Trigger>
+              <Accordion.Panel inverse={args.inverse}>
                 <PanelContent inverse={args.inverse} />
-              </AccordionPanel>
-            </AccordionItem>
+              </Accordion.Panel>
+            </Accordion.Item>
           ))}
         </Accordion>
       </Stack>
@@ -284,14 +282,17 @@ export const GroupOpenStart: Story = {
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion defaultValue="item-2" inverse={args.inverse}>
           {accordionIds.map((id, i) => (
-            <AccordionItem inverse={args.inverse} key={i} id={`item-${id}`}>
-              <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
+            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+              <Accordion.Trigger
+                iconName={args.iconName}
+                inverse={args.inverse}
+              >
                 {args.triggerCopy} {`  ${id + 1}`}
-              </AccordionTrigger>
-              <AccordionPanel inverse={args.inverse}>
+              </Accordion.Trigger>
+              <Accordion.Panel inverse={args.inverse}>
                 <PanelContent inverse={args.inverse} />
-              </AccordionPanel>
-            </AccordionItem>
+              </Accordion.Panel>
+            </Accordion.Item>
           ))}
         </Accordion>
       </Stack>
@@ -316,14 +317,17 @@ export const GroupOpenStartInverse: Story = {
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion defaultValue="item-0" inverse={args.inverse}>
           {accordionIds.map((id, i) => (
-            <AccordionItem inverse={args.inverse} key={i} id={`item-${id}`}>
-              <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
+            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+              <Accordion.Trigger
+                iconName={args.iconName}
+                inverse={args.inverse}
+              >
                 {args.triggerCopy} {`  ${id + 1}`}
-              </AccordionTrigger>
-              <AccordionPanel inverse={args.inverse}>
+              </Accordion.Trigger>
+              <Accordion.Panel inverse={args.inverse}>
                 <PanelContent inverse={args.inverse} />
-              </AccordionPanel>
-            </AccordionItem>
+              </Accordion.Panel>
+            </Accordion.Item>
           ))}
         </Accordion>
       </Stack>
@@ -347,14 +351,17 @@ export const GroupReverse: Story = {
       <Stack direction="column" marginY={10} marginX={10} gap={2}>
         <Accordion inverse={args.inverse}>
           {accordionIds.map((id, i) => (
-            <AccordionItem inverse={args.inverse} key={i} id={`item-${id}`}>
-              <AccordionPanel inverse={args.inverse}>
+            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+              <Accordion.Panel inverse={args.inverse}>
                 <PanelContent inverse={args.inverse} />
-              </AccordionPanel>
-              <AccordionTrigger iconName={args.iconName} inverse={args.inverse}>
+              </Accordion.Panel>
+              <Accordion.Trigger
+                iconName={args.iconName}
+                inverse={args.inverse}
+              >
                 {args.triggerCopy} {`  ${id + 1}`}
-              </AccordionTrigger>
-            </AccordionItem>
+              </Accordion.Trigger>
+            </Accordion.Item>
           ))}
         </Accordion>
       </Stack>
@@ -386,14 +393,14 @@ export const GroupWithAlternateIcons: Story = {
             const { id, icon } = acc;
 
             return (
-              <AccordionItem inverse={args.inverse} key={i} id={`item-${id}`}>
-                <AccordionTrigger inverse={args.inverse} iconName={icon}>
+              <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
+                <Accordion.Trigger inverse={args.inverse} iconName={icon}>
                   {args.triggerCopy} {`  ${id + 1}`}
-                </AccordionTrigger>
-                <AccordionPanel inverse={args.inverse}>
+                </Accordion.Trigger>
+                <Accordion.Panel inverse={args.inverse}>
                   <PanelContent inverse={args.inverse} />
-                </AccordionPanel>
-              </AccordionItem>
+                </Accordion.Panel>
+              </Accordion.Item>
             );
           })}
         </Accordion>

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -10,7 +10,10 @@ const meta: Meta<typeof Accordion> = {
   component: Accordion,
   tags: ['autodocs'],
   parameters: {
-    layout: 'fullscreen',
+    layout: 'padded',
+    chromatic: {
+      viewports: [320, 640, 768, 1024],
+    },
   },
 };
 
@@ -60,7 +63,7 @@ export const Base: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+      <Stack direction="column" marginY={0} marginX={0} gap={2}>
         <Accordion>
           <Accordion.Item id="1">
             <Accordion.Trigger iconName={args.iconName}>
@@ -86,7 +89,7 @@ export const Inverse: Story = {
     backgrounds: { default: 'dark' },
   },
   render: (args) => (
-    <Stack direction="column" marginY={10} marginX={10} gap={2}>
+    <Stack direction="column" marginY={0} marginX={0} gap={2}>
       <Accordion inverse={args.inverse}>
         <Accordion.Item id="1" inverse={args.inverse}>
           <Accordion.Trigger iconName={args.iconName} inverse={args.inverse}>
@@ -109,7 +112,7 @@ export const StartingOpen: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+      <Stack direction="column" marginY={0} marginX={0} gap={2}>
         <Accordion defaultValue="1">
           <Accordion.Item id="1">
             <Accordion.Trigger iconName={args.iconName}>
@@ -134,7 +137,7 @@ export const WithAlternateIcon: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+      <Stack direction="column" marginY={0} marginX={0} gap={2}>
         <Accordion>
           <Accordion.Item id="1">
             <Accordion.Trigger iconName={args.iconName}>
@@ -159,7 +162,7 @@ export const WithNoIcon: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+      <Stack direction="column" marginY={0} marginX={0} gap={2}>
         <Accordion>
           <Accordion.Item id="1">
             <Accordion.Trigger iconName={args.iconName}>
@@ -183,7 +186,7 @@ export const Reversed: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+      <Stack direction="column" marginY={0} marginX={0} gap={2}>
         <Accordion>
           <Accordion.Item id="1">
             <Accordion.Panel>
@@ -210,7 +213,7 @@ export const ReversedInverse: Story = {
     backgrounds: { default: 'dark' },
   },
   render: (args) => (
-    <Stack direction="column" marginY={10} marginX={10} gap={2}>
+    <Stack direction="column" marginY={0} marginX={0} gap={2}>
       <Accordion inverse={args.inverse}>
         <Accordion.Item id="1" inverse={args.inverse}>
           <Accordion.Panel inverse={args.inverse}>
@@ -233,7 +236,7 @@ export const Group: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+      <Stack direction="column" marginY={0} marginX={0} gap={2}>
         <Accordion>
           {accordions.map((acc, i) => {
             const { id, triggerCopy } = acc;
@@ -266,7 +269,7 @@ export const GroupInverse: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+      <Stack direction="column" marginY={0} marginX={0} gap={2}>
         <Accordion inverse={args.inverse}>
           {accordions.map((acc, i) => {
             const { id, triggerCopy } = acc;
@@ -300,7 +303,7 @@ export const GroupOpenStart: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+      <Stack direction="column" marginY={0} marginX={0} gap={2}>
         <Accordion defaultValue="item-2" inverse={args.inverse}>
           {accordions.map((acc, i) => {
             const { id, triggerCopy } = acc;
@@ -337,7 +340,7 @@ export const GroupOpenStartInverse: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+      <Stack direction="column" marginY={0} marginX={0} gap={2}>
         <Accordion defaultValue="item-0" inverse={args.inverse}>
           {accordions.map((acc, i) => {
             const { id, triggerCopy } = acc;
@@ -373,7 +376,7 @@ export const GroupReverse: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+      <Stack direction="column" marginY={0} marginX={0} gap={2}>
         <Accordion inverse={args.inverse}>
           {accordions.map((acc, i) => {
             const { id, triggerCopy } = acc;
@@ -409,7 +412,7 @@ export const GroupWithAlternateIcons: Story = {
   },
   render: (args) => {
     return (
-      <Stack direction="column" marginY={10} marginX={10} gap={2}>
+      <Stack direction="column" marginY={0} marginX={0} gap={2}>
         <Accordion inverse={args.inverse}>
           {accordions.map((acc, i) => {
             const { id, triggerCopy, icon } = acc;

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -19,8 +19,7 @@ type Story = StoryObj<typeof Accordion>;
 const accordions = [
   {
     id: 0,
-    triggerCopy:
-      'Does Chromatic replace Jest or Enzyme? Does Chromatic replace Jest or Enzyme? Does Chromatic replace Jest or Enzyme? Does Chromatic replace Jest or Enzyme?',
+    triggerCopy: 'Does Chromatic replace Jest or Enzyme?',
     icon: 'cloudhollow',
   },
   {

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 import { Stack } from '../Stack';
 import { Text } from '../Text';
-import { Placeholder } from '../_localComponents/Placeholder';
 import { Accordion } from './Accordion';
 
 const meta: Meta<typeof Accordion> = {

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -10,9 +10,6 @@ const meta: Meta<typeof Accordion> = {
   tags: ['autodocs'],
   parameters: {
     layout: 'padded',
-    chromatic: {
-      viewports: [320, 640, 768, 1024],
-    },
   },
 };
 
@@ -22,7 +19,8 @@ type Story = StoryObj<typeof Accordion>;
 const accordions = [
   {
     id: 0,
-    triggerCopy: 'Does Chromatic replace Jest or Enzyme?',
+    triggerCopy:
+      'Does Chromatic replace Jest or Enzyme? Does Chromatic replace Jest or Enzyme? Does Chromatic replace Jest or Enzyme? Does Chromatic replace Jest or Enzyme?',
     icon: 'cloudhollow',
   },
   {
@@ -63,6 +61,9 @@ export const Base: Story = {
   },
   parameters: {
     backgrounds: { default: 'light' },
+    chromatic: {
+      viewports: [320, 640, 768, 1024],
+    },
   },
   render: (args) => {
     return (
@@ -88,6 +89,9 @@ export const Inverse: Story = {
   },
   parameters: {
     backgrounds: { default: 'dark' },
+    chromatic: {
+      viewports: [320, 640, 768, 1024],
+    },
   },
   render: (args) => (
     <Accordion inverse={args.inverse}>
@@ -170,58 +174,16 @@ export const WithNoIcon: Story = {
     );
   },
 };
-
-export const Reversed: Story = {
-  ...Base,
-  args: {
-    ...Base.args,
-    inverse: false,
-  },
-  render: (args) => {
-    return (
-      <Accordion>
-        <Accordion.Item id="1">
-          <Accordion.Panel>
-            <ExamplePanelContent inverse={args.inverse} />
-          </Accordion.Panel>
-          <Accordion.Trigger iconName={args.iconName}>
-            {args.triggerCopy}
-          </Accordion.Trigger>
-        </Accordion.Item>
-      </Accordion>
-    );
-  },
-};
-
-export const ReversedInverse: Story = {
-  ...Base,
-  name: 'Reversed and Inverse',
-  args: {
-    ...Base.args,
-    inverse: true,
-  },
-  parameters: {
-    backgrounds: { default: 'dark' },
-  },
-  render: (args) => (
-    <Accordion inverse={args.inverse}>
-      <Accordion.Item id="1" inverse={args.inverse}>
-        <Accordion.Panel inverse={args.inverse}>
-          <ExamplePanelContent inverse={args.inverse} />
-        </Accordion.Panel>
-        <Accordion.Trigger iconName={args.iconName} inverse={args.inverse}>
-          {args.triggerCopy}
-        </Accordion.Trigger>
-      </Accordion.Item>
-    </Accordion>
-  ),
-};
-
 export const Group: Story = {
   ...Base,
   args: {
     ...Base.args,
     inverse: false,
+  },
+  parameters: {
+    chromatic: {
+      viewports: [320, 640, 768, 1024],
+    },
   },
   render: (args) => {
     return (
@@ -253,6 +215,9 @@ export const GroupInverse: Story = {
   },
   parameters: {
     backgrounds: { default: 'dark' },
+    chromatic: {
+      viewports: [320, 640, 768, 1024],
+    },
   },
   render: (args) => {
     return (
@@ -266,7 +231,7 @@ export const GroupInverse: Story = {
                 iconName={args.iconName}
                 inverse={args.inverse}
               >
-                {triggerCopy} {`  ${id + 1}`}
+                {triggerCopy}
               </Accordion.Trigger>
               <Accordion.Panel inverse={args.inverse}>
                 <ExamplePanelContent inverse={args.inverse} />
@@ -338,40 +303,6 @@ export const GroupOpenStartInverse: Story = {
               <Accordion.Panel inverse={args.inverse}>
                 <ExamplePanelContent inverse={args.inverse} />
               </Accordion.Panel>
-            </Accordion.Item>
-          );
-        })}
-      </Accordion>
-    );
-  },
-};
-
-export const GroupReverse: Story = {
-  ...Base,
-  args: {
-    ...Base.args,
-    inverse: false,
-  },
-  parameters: {
-    backgrounds: { default: 'light' },
-  },
-  render: (args) => {
-    return (
-      <Accordion inverse={args.inverse}>
-        {accordions.map((acc, i) => {
-          const { id, triggerCopy } = acc;
-
-          return (
-            <Accordion.Item inverse={args.inverse} key={i} id={`item-${id}`}>
-              <Accordion.Panel inverse={args.inverse}>
-                <ExamplePanelContent inverse={args.inverse} />
-              </Accordion.Panel>
-              <Accordion.Trigger
-                iconName={args.iconName}
-                inverse={args.inverse}
-              >
-                {triggerCopy} {`  ${id + 1}`}
-              </Accordion.Trigger>
             </Accordion.Item>
           );
         })}

--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -35,7 +35,11 @@ const accordions = [
     triggerCopy: 'How is this compared to Selenium, Cypress, or Playwright?',
     icon: 'accessibilityalt',
   },
-  { id: 3, triggerCopy: 'Why run visual tests in the cloud?', icon: 'heart' },
+  {
+    id: 3,
+    triggerCopy: 'Why run visual tests in the cloud?',
+    icon: 'heart',
+  },
 ];
 
 const PanelContent = ({ inverse }) => {

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -54,11 +54,10 @@ const Item = styled(Acc.Item)<{
   border-bottom: 0;
   flex-flow: column nowrap;
   overflow: hidden;
-  padding: ${spacing[2]} ${spacing[4]};
   transition: all 0.2s ease-in-out;
 
-  ${minSm} {
-    padding: ${spacing[2]} ${spacing[8]};
+  &[data-state='open'] {
+    padding-bottom: ${spacing[8]};
   }
 
   &:first-of-type {
@@ -90,22 +89,21 @@ const Item = styled(Acc.Item)<{
 const Trigger = styled(Acc.Trigger)<{
   inverse?: boolean;
 }>`
-  ${typography.body14};
-  align-items: start;
+  ${typography.body16};
+  align-items: center;
   background: none;
   border: 0;
   color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
   cursor: pointer;
   display: flex;
   justify-content: space-between;
-  padding: ${spacing[2]} 0;
+  padding: calc(${spacing[4]} + 1px) ${spacing[8]};
   text-align: left;
-  transition: all 0.16s ease-in-out;
+  transition: all 300ms ease-in-out;
   width: 100%;
 
-  ${minSm} {
-    ${typography.body16};
-    align-items: center;
+  [data-state='open'] & {
+    padding-top: ${spacing[8]};
   }
 
   &:hover,
@@ -121,19 +119,16 @@ const StyledIcon = styled(Icon)<{
   flex-basis: ${spacing[4]};
   flex-shrink: 0;
   margin-left: ${spacing[5]};
-
-  ${minSm} {
-    margin-left: ${spacing[4]};
-  }
 `;
 
 // the collapsible content of each item
 const Panel = styled(Acc.Content)<{
   inverse?: boolean;
 }>`
-  ${typography.body14};
+  ${typography.body16};
   color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
   overflow: hidden;
+  padding: 0 ${spacing[12]} 0 ${spacing[8]};
 
   &[data-state='open'] {
     animation: ${slideDown} 300ms cubic-bezier(0.87, 0, 0.13, 1);
@@ -144,12 +139,7 @@ const Panel = styled(Acc.Content)<{
   }
 
   & > * {
-    ${typography.body14};
     color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
-
-    ${minSm} {
-      ${typography.body16};
-    }
   }
 `;
 

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -105,7 +105,10 @@ const StyledIcon = styled(Icon)<{
 `;
 
 // the collapsible content of each item
-const Panel = styled(Acc.Content)`
+const Panel = styled(Acc.Content)<{
+  inverse?: boolean;
+}>`
+  color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
   overflow: hidden;
 
   &[data-state='open'] {
@@ -114,6 +117,11 @@ const Panel = styled(Acc.Content)`
 
   &[data-state='closed'] {
     animation: ${slideUp} 300ms cubic-bezier(0.87, 0, 0.13, 1);
+  }
+
+  & > * {
+    // to ensure we override any passed components with inherited styles
+    color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
   }
 `;
 
@@ -153,7 +161,7 @@ AccordionTrigger.displayName = 'AccordionTrigger';
 export const AccordionPanel = forwardRef<any, AccordionProps>(
   ({ inverse, children, ...props }, forwardedRef) => {
     return (
-      <Panel ref={forwardedRef} {...props}>
+      <Panel inverse={inverse} ref={forwardedRef} {...props}>
         {children}
       </Panel>
     );

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -58,7 +58,7 @@ const Item = styled(Acc.Item)<{
     inverse ? color.whiteTr10 : color.slate200};
   flex-flow: column nowrap;
   overflow: hidden;
-  padding: ${spacing[4]} ${spacing[8]} ${spacing[2]};
+  padding: ${spacing[2]} ${spacing[8]};
 
   &:last-of-type {
     border-bottom-left-radius: 4px;
@@ -85,8 +85,7 @@ const Trigger = styled(Acc.Trigger)<{
   font-size: ${fontSize[16]};
   font-weight: 400;
   justify-content: space-between;
-  padding: 0;
-  padding-bottom: ${spacing[2]};
+  padding: ${spacing[2]} 0;
   transition: all 0.16s ease-in-out;
   width: 100%;
 
@@ -120,7 +119,6 @@ const Panel = styled(Acc.Content)<{
   }
 
   & > * {
-    // to ensure we override any passed components with inherited styles
     color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
   }
 `;

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -97,7 +97,7 @@ const Trigger = styled(Acc.Trigger)<{
   cursor: pointer;
   display: flex;
   justify-content: space-between;
-  padding: calc(${spacing[4]} + 1px) 30px;
+  padding: calc(${spacing[4]} + 1px) ${spacing[8]};
   text-align: left;
   transition: all 300ms ease-in-out;
   width: 100%;
@@ -128,7 +128,7 @@ const Panel = styled(Acc.Content)<{
   ${typography.body16};
   color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
   overflow: hidden;
-  padding: 0 ${spacing[12]} 0 30px;
+  padding: 0 ${spacing[12]} 0 ${spacing[8]};
 
   &[data-state='open'] {
     animation: ${slideDown} 300ms cubic-bezier(0.87, 0, 0.13, 1);

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -126,7 +126,7 @@ const Panel = styled(Acc.Content)<{
 // Wrapper for each accordion item's trigger & content
 // expects AccordionTrigger & AccordionPanel as children
 // radix requires custom components to have refs passed in
-export const AccordionItem = forwardRef<any, AccordionProps>(
+const AccordionItem = forwardRef<any, AccordionProps>(
   ({ inverse, id = '0', children, ...props }, forwardedRef) => (
     <Item value={id} inverse={inverse} {...props} ref={forwardedRef}>
       {children}
@@ -138,7 +138,7 @@ AccordionItem.displayName = 'AccordionItem';
 
 // the button controlling the open/closed state of each item
 // radix requires custom components to have refs passed in
-export const AccordionTrigger = forwardRef<any, AccordionProps>(
+const AccordionTrigger = forwardRef<any, AccordionProps>(
   (
     { inverse, iconName = 'arrowdown', iconSize = 14, children, ...props },
     forwardedRef
@@ -156,7 +156,7 @@ AccordionTrigger.displayName = 'AccordionTrigger';
 
 // the collapsible content of each item
 // radix requires custom components to have refs passed in
-export const AccordionPanel = forwardRef<any, AccordionProps>(
+const AccordionPanel = forwardRef<any, AccordionProps>(
   ({ inverse, children, ...props }, forwardedRef) => {
     return (
       <Panel inverse={inverse} ref={forwardedRef} {...props}>
@@ -188,3 +188,7 @@ export const Accordion: FC<AccordionProps> = ({
     </AccordionWrapper>
   );
 };
+
+Accordion.Item = AccordionItem;
+Accordion.Trigger = AccordionTrigger;
+Accordion.Panel = AccordionPanel;

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -97,7 +97,7 @@ const Trigger = styled(Acc.Trigger)<{
   cursor: pointer;
   display: flex;
   justify-content: space-between;
-  padding: calc(${spacing[4]} + 1px) ${spacing[8]};
+  padding: calc(${spacing[4]} + 1px) 30px;
   text-align: left;
   transition: all 300ms ease-in-out;
   width: 100%;
@@ -128,7 +128,7 @@ const Panel = styled(Acc.Content)<{
   ${typography.body16};
   color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
   overflow: hidden;
-  padding: 0 ${spacing[12]} 0 ${spacing[8]};
+  padding: 0 ${spacing[12]} 0 30px;
 
   &[data-state='open'] {
     animation: ${slideDown} 300ms cubic-bezier(0.87, 0, 0.13, 1);

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -1,7 +1,8 @@
 import React, { FC, useState, forwardRef } from 'react';
 import { keyframes, styled } from '@storybook/theming';
 import * as Acc from '@radix-ui/react-accordion';
-import { color, fontFamily, fontSize, spacing } from '../_tokens';
+import { breakpoint, color, fontFamily, fontSize, spacing } from '../_tokens';
+import { minSm, typography } from '../_helpers';
 import { Icon } from '../Icon';
 import type { Icons } from '../Icon/Icon';
 
@@ -39,36 +40,49 @@ const slideUp = keyframes`
 const AccordionWrapper = styled(Acc.Root)<{
   inverse?: boolean;
 }>`
-  border: 1px solid;
-  border-bottom: 0;
-  border-color: ${({ inverse }) =>
-    inverse ? color.whiteTr10 : color.slate200};
-  border-radius: 5px;
+  ${typography.body16};
   color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
-  font-family: ${fontFamily.sans};
-  font-size: ${fontSize[16]};
 `;
 
 // Wrapper for each accordion item's trigger & content
 const Item = styled(Acc.Item)<{
   inverse?: boolean;
 }>`
-  border-bottom: 1px solid;
+  border: 1px solid;
   border-color: ${({ inverse }) =>
-    inverse ? color.whiteTr10 : color.slate200};
+    inverse ? color.whiteTr10 : color.blackTr10};
+  border-bottom: 0;
   flex-flow: column nowrap;
   overflow: hidden;
-  padding: ${spacing[2]} ${spacing[8]};
+  padding: ${spacing[2]} ${spacing[4]};
+  transition: all 0.2s ease-in-out;
 
-  &:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+  ${minSm} {
+    padding: ${spacing[2]} ${spacing[8]};
   }
 
-  &:focus-within {
-    position: relative;
-    z-index: 1;
-    box-shadow: 0 0 0 2px var(--mauve-12);
+  &:first-of-type {
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+  }
+
+  &:last-of-type {
+    border-bottom: 1px solid;
+    border-bottom-color: ${({ inverse }) =>
+      inverse ? color.whiteTr10 : color.blackTr10};
+    border-bottom-left-radius: 5px;
+    border-bottom-right-radius: 5px;
+  }
+
+  &:focus-within,
+  &:hover {
+    outline: none;
+    border-color: ${color.blue500};
+  }
+
+  &:hover + &,
+  &:focus-within + & {
+    border-top-color: ${color.blue500};
   }
 `;
 
@@ -76,37 +90,48 @@ const Item = styled(Acc.Item)<{
 const Trigger = styled(Acc.Trigger)<{
   inverse?: boolean;
 }>`
-  align-items: center;
+  ${typography.body14};
+  align-items: start;
   background: none;
   border: 0;
   color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
   cursor: pointer;
   display: flex;
-  font-size: ${fontSize[16]};
-  font-weight: 400;
   justify-content: space-between;
   padding: ${spacing[2]} 0;
+  text-align: left;
   transition: all 0.16s ease-in-out;
   width: 100%;
 
+  ${minSm} {
+    ${typography.body16};
+    align-items: center;
+  }
+
   &:hover,
   &:focus {
-    color: ${({ inverse }) => (inverse ? color.slate50 : color.slate700)};
-    transform: translateY(-1px);
+    outline: none;
   }
 `;
 
 const StyledIcon = styled(Icon)<{
   inverse?: boolean;
 }>`
-  fill: ${({ inverse }) => (inverse ? color.white : color.slate800)};
-  margin-left: ${spacing[2]};
+  fill: currentColor;
+  flex-basis: ${spacing[4]};
+  flex-shrink: 0;
+  margin-left: ${spacing[5]};
+
+  ${minSm} {
+    margin-left: ${spacing[4]};
+  }
 `;
 
 // the collapsible content of each item
 const Panel = styled(Acc.Content)<{
   inverse?: boolean;
 }>`
+  ${typography.body14};
   color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
   overflow: hidden;
 
@@ -119,7 +144,12 @@ const Panel = styled(Acc.Content)<{
   }
 
   & > * {
+    ${typography.body14};
     color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
+
+    ${minSm} {
+      ${typography.body16};
+    }
   }
 `;
 
@@ -128,7 +158,13 @@ const Panel = styled(Acc.Content)<{
 // radix requires custom components to have refs passed in
 const AccordionItem = forwardRef<any, AccordionProps>(
   ({ inverse, id = '0', children, ...props }, forwardedRef) => (
-    <Item value={id} inverse={inverse} {...props} ref={forwardedRef}>
+    <Item
+      value={id}
+      inverse={inverse}
+      {...props}
+      ref={forwardedRef}
+      className="accordion-item"
+    >
       {children}
     </Item>
   )
@@ -146,7 +182,13 @@ const AccordionTrigger = forwardRef<any, AccordionProps>(
     <Trigger ref={forwardedRef} inverse={inverse} {...props}>
       {children}
       {iconName && (
-        <StyledIcon inverse={inverse} name={iconName} size={iconSize} />
+        <StyledIcon
+          aria-hidden="true"
+          inverse={inverse}
+          name={iconName}
+          size={iconSize}
+          tabIndex={-1}
+        />
       )}
     </Trigger>
   )

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -1,0 +1,184 @@
+import React, { FC, useState, forwardRef } from 'react';
+import { keyframes, styled } from '@storybook/theming';
+import * as Acc from '@radix-ui/react-accordion';
+import { color, fontFamily, fontSize, spacing } from '../_tokens';
+import { Icon } from '../Icon';
+import type { Icons } from '../Icon/Icon';
+
+export interface AccordionProps {
+  children: React.ReactNode | string;
+  defaultValue?: string | undefined;
+  iconName?: Icons | false;
+  iconSize?: number;
+  id?: string | undefined;
+  inverse?: boolean;
+  value?: string;
+  triggerCopy?: string;
+}
+
+const slideDown = keyframes`
+  from {
+    height: 0;
+  }
+  to {
+    // dynamically set height
+    height: var(--radix-accordion-content-height);
+  }
+}`;
+
+const slideUp = keyframes`
+  from {
+    height: var(--radix-accordion-content-height);
+  }
+  to {
+    height: 0;
+  }
+}`;
+
+// Outermost accordion container
+const AccordionWrapper = styled(Acc.Root)<{
+  inverse?: boolean;
+}>`
+  border: 1px solid;
+  border-bottom: 0;
+  border-color: ${({ inverse }) =>
+    inverse ? color.whiteTr10 : color.slate200};
+  border-radius: 5px;
+  color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
+  font-family: ${fontFamily.sans};
+  font-size: ${fontSize[16]};
+`;
+
+// Wrapper for each accordion item's trigger & content
+const Item = styled(Acc.Item)<{
+  inverse?: boolean;
+}>`
+  border-bottom: 1px solid;
+  border-color: ${({ inverse }) =>
+    inverse ? color.whiteTr10 : color.slate200};
+  flex-flow: column nowrap;
+  overflow: hidden;
+  padding: ${spacing[4]} ${spacing[8]} ${spacing[2]};
+
+  &:last-of-type {
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
+
+  &:focus-within {
+    position: relative;
+    z-index: 1;
+    box-shadow: 0 0 0 2px var(--mauve-12);
+  }
+`;
+
+// the button controlling the open/closed state of each item
+const Trigger = styled(Acc.Trigger)<{
+  inverse?: boolean;
+}>`
+  align-items: center;
+  background: none;
+  border: 0;
+  color: ${({ inverse }) => (inverse ? color.white : color.slate800)};
+  cursor: pointer;
+  display: flex;
+  font-size: ${fontSize[16]};
+  font-weight: 400;
+  justify-content: space-between;
+  padding: 0;
+  padding-bottom: ${spacing[2]};
+  transition: all 0.16s ease-in-out;
+  width: 100%;
+
+  &:hover,
+  &:focus {
+    color: ${({ inverse }) => (inverse ? color.slate50 : color.slate700)};
+    transform: translateY(-1px);
+  }
+`;
+
+const StyledIcon = styled(Icon)<{
+  inverse?: boolean;
+}>`
+  fill: ${({ inverse }) => (inverse ? color.white : color.slate800)};
+  margin-left: ${spacing[2]};
+`;
+
+// the collapsible content of each item
+const Panel = styled(Acc.Content)`
+  overflow: hidden;
+
+  &[data-state='open'] {
+    animation: ${slideDown} 300ms cubic-bezier(0.87, 0, 0.13, 1);
+  }
+
+  &[data-state='closed'] {
+    animation: ${slideUp} 300ms cubic-bezier(0.87, 0, 0.13, 1);
+  }
+`;
+
+// Wrapper for each accordion item's trigger & content
+// expects AccordionTrigger & AccordionPanel as children
+// radix requires custom components to have refs passed in
+export const AccordionItem = forwardRef<any, AccordionProps>(
+  ({ inverse, id = '0', children, ...props }, forwardedRef) => (
+    <Item value={id} inverse={inverse} {...props} ref={forwardedRef}>
+      {children}
+    </Item>
+  )
+);
+
+AccordionItem.displayName = 'AccordionItem';
+
+// the button controlling the open/closed state of each item
+// radix requires custom components to have refs passed in
+export const AccordionTrigger = forwardRef<any, AccordionProps>(
+  (
+    { inverse, iconName = 'arrowdown', iconSize = 14, children, ...props },
+    forwardedRef
+  ) => (
+    <Trigger ref={forwardedRef} inverse={inverse} {...props}>
+      {children}
+      {iconName && (
+        <StyledIcon inverse={inverse} name={iconName} size={iconSize} />
+      )}
+    </Trigger>
+  )
+);
+
+AccordionTrigger.displayName = 'AccordionTrigger';
+
+// the collapsible content of each item
+// radix requires custom components to have refs passed in
+export const AccordionPanel = forwardRef<any, AccordionProps>(
+  ({ inverse, children, ...props }, forwardedRef) => {
+    return (
+      <Panel ref={forwardedRef} {...props}>
+        {children}
+      </Panel>
+    );
+  }
+);
+
+AccordionPanel.displayName = 'AccordionPanel';
+
+// Outermost accordion container; expects N <AccordionItem /> as children
+export const Accordion: FC<AccordionProps> = ({
+  defaultValue,
+  inverse,
+  children,
+  iconName,
+  ...props
+}) => {
+  return (
+    <AccordionWrapper
+      inverse={inverse}
+      type="single"
+      collapsible
+      defaultValue={defaultValue}
+      {...props}
+    >
+      {children}
+    </AccordionWrapper>
+  );
+};

--- a/src/Accordion/index.ts
+++ b/src/Accordion/index.ts
@@ -1,0 +1,6 @@
+export {
+  Accordion,
+  AccordionTrigger,
+  AccordionPanel,
+  AccordionItem,
+} from './Accordion';

--- a/src/Accordion/index.ts
+++ b/src/Accordion/index.ts
@@ -1,6 +1,1 @@
-export {
-  Accordion,
-  AccordionTrigger,
-  AccordionPanel,
-  AccordionItem,
-} from './Accordion';
+export { Accordion } from './Accordion';

--- a/src/CustomerStoryHero/CustomerStoryHero.stories.tsx
+++ b/src/CustomerStoryHero/CustomerStoryHero.stories.tsx
@@ -37,5 +37,5 @@ export const Base: Story = {
   parameters: {
     layout: 'centered',
   },
-  render: ({ items }) => <CustomerStoryHero items={items} />,
+  render: (args) => <CustomerStoryHero items={args.items} />,
 };

--- a/src/CustomerStoryHero/CustomerStoryHero.tsx
+++ b/src/CustomerStoryHero/CustomerStoryHero.tsx
@@ -87,14 +87,12 @@ export interface SharedHeroProps {
 }
 
 export interface CustomerStoryHeroProps {
-  items: [
-    {
-      imgPath: string;
-      imgAlt: string;
-      caption: React.ReactNode | string;
-      position?: 'first' | 'last';
-    }
-  ];
+  items: {
+    imgPath?: string;
+    imgAlt?: string;
+    caption?: React.ReactNode | string;
+    position?: 'first' | 'last';
+  }[];
 }
 
 export const CustomerStoryHero: FC<CustomerStoryHeroProps> = ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1689,6 +1689,22 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-accordion@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.1.2.tgz#738441f7343e5142273cdef94d12054c3287966f"
+  integrity sha512-fDG7jcoNKVjSK6yfmuAs0EnPDro0WMXIhMtXdTBWqEioVW206ku+4Lw07e+13lUkFkpoEQ2PdeMIAGpdqEAmDg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collapsible" "1.0.3"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
 "@radix-ui/react-arrow@1.0.2":
   version "1.0.2"
   resolved "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.2.tgz#93b0ff95f65e2264a05b14ef1031ec798243dd6f"
@@ -1719,6 +1735,21 @@
     "@radix-ui/react-primitive" "1.0.2"
     "@radix-ui/react-use-controllable-state" "1.0.0"
     "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/react-collapsible@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.0.3.tgz#df0e22e7a025439f13f62d4e4a9e92c4a0df5b81"
+  integrity sha512-UBmVDkmR6IvDsloHVN+3rtx4Mi5TFvylYXpluuv0f37dtaz3H99bp8No0LGXRigVpl3UAT4l9j6bIchh42S/Gg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
 
 "@radix-ui/react-collection@1.0.2":
   version "1.0.2"


### PR DESCRIPTION
### `<Accordion />`
* I used the [radix accordion](https://www.radix-ui.com/primitives/docs/components/accordion) as the base so I didn't have to reinvent the a11y details
* ~rather than exporting a single `Accordion` component that can be passed some array of `{title: ..., content: ...}` data, I opted to export the outer `Accordion` as well as `AccordionItem`, `AccordionTrigger`, and  `AccordionPanel` so each accordion can be composed as needed.~
* The `Accordion` subcomponents, `Item`, `Trigger`, and `Panel`, are exports on the larger `Accordion` component and accessed via dot notation.
* the usage ends up looking like:
```jsx
<Accordion>
  <Accordion.Item>
    <Accordion.Trigger>
      Trigger content
    </Accordion.Trigger>
    <Accordion.Panel>
      Collapsible content
    </Accordion.Panel>
  </Accordion.Item>
</Accordion>
```
* both `Accordion.Trigger` and `Accordion.Panel` can take a string, JSX, native elements, or whatever as children
* `Accordion.Trigger` and `Accordion.Panel` don't need to be included in any particular order, so long as they're both children of `Accordion.Item` and connected via `id`, so content can be placed between them, the trigger can be placed beneath the panel, etc.
* everything else should be fairly straightforward

---  

![accordion cat](https://static.wikia.nocookie.net/5398a028-d27d-47cf-b838-d3c7d4fe781e/scale-to-width/755)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.15.13--canary.72.ac39697.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/tetra@1.15.13--canary.72.ac39697.0
  # or 
  yarn add @chromaui/tetra@1.15.13--canary.72.ac39697.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
