### PR TITLE
Update Header and Footer spacing

### DIFF
--- a/src/Footer/Footer.tsx
+++ b/src/Footer/Footer.tsx
@@ -12,8 +12,11 @@ import { FooterColumn, FooterSocialItem, HomeItem } from './types';
 const Columns = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: ${spacing[8]};
-  margin-bottom: ${spacing[16]};
+  gap: ${spacing[12]} ${spacing[8]};
+  margin-bottom: ${spacing[12]};
+  ${minSm} {
+    margin-bottom: ${spacing[20]};
+  }
 `;
 
 const Column = styled.div`
@@ -27,6 +30,7 @@ const ColumnTitle = styled.div<{ inverse?: boolean }>`
   ${typography.subheadingLarge};
   color: ${({ inverse }) => (inverse ? color.white : color.slate500)};
   margin-bottom: ${spacing[1]};
+  opacity: ${({ inverse }) => (inverse ? 0.5 : 1)};
 `;
 
 const FooterLink = styled(LinkWithWrapper, {
@@ -86,8 +90,8 @@ const FooterWrapper = styled.footer<{ inverse?: boolean }>`
   padding-bottom: ${spacing[12]};
 
   ${minSm} {
-    padding-top: ${spacing[16]};
-    padding-bottom: ${spacing[16]};
+    padding-top: ${spacing[20]};
+    padding-bottom: ${spacing[20]};
   }
 `;
 
@@ -104,12 +108,14 @@ const Colophon = styled(HStack)`
 
   svg {
     flex: none;
+    margin-top: -5px; //optical alignment for logo and colophon text
   }
 `;
 
 const ColophonText = styled.div<{ inverse?: boolean }>`
   ${typography.body14};
   color: ${({ inverse }) => (inverse ? color.white : color.slate500)};
+  opacity: ${({ inverse }) => (inverse ? 0.5 : 1)};
 `;
 
 const HomeLink = styled(LinkWithWrapper)`

--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -20,7 +20,7 @@ const Wrapper = styled.div<WrapperProps>`
   ${resetCSS}
 
   display: flex;
-  height: 60px;
+  height: 72px;
   align-items: center;
   justify-content: space-between;
 
@@ -47,10 +47,6 @@ const LogoLink = styled(LinkWithWrapper)`
   &:focus-visible {
     box-shadow: 0 0 0 2px rgba(30, 167, 253, 0.3);
     outline: none;
-  }
-
-  ${minSm} {
-    margin-top: -4px;
   }
 `;
 

--- a/src/_helpers/typography.ts
+++ b/src/_helpers/typography.ts
@@ -207,7 +207,7 @@ const subheading = css`
 
 const subheadingLarge = css`
   font-family: ${fontFamily.sans};
-  font-size: ${fontSize[14]};
+  font-size: 13px;
   line-height: ${lineHeight[20]};
   font-weight: ${fontWeight.bold};
   letter-spacing: 0.35em;


### PR DESCRIPTION
Adjust logo spacing to match Chromatic's updated marketing header:
<img width="513" alt="image" src="https://github.com/chromaui/tetra/assets/263385/d7654eca-4561-4098-a228-3370dadc4b5b">

Adjust mobile spacing to match Storybook's mobile header which uses a similar pattern:
<img width="375" alt="image" src="https://github.com/chromaui/tetra/assets/263385/18a77fa7-7e5e-44c4-8762-15eab01a7373">

Adjust footer to match sizing patterns used in marketing site
<img width="1097" alt="image" src="https://github.com/chromaui/tetra/assets/263385/d33f1b03-3055-4e2e-b48f-2127258b4197">


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.15.8--canary.73.dcdf709.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/tetra@1.15.8--canary.73.dcdf709.0
  # or 
  yarn add @chromaui/tetra@1.15.8--canary.73.dcdf709.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
