### PR TITLE
make the default link size 1em (so it matches the surrounding text)

### DIFF
--- a/src/Header/Header.stories.tsx
+++ b/src/Header/Header.stories.tsx
@@ -28,7 +28,7 @@ export const DesktopLight: Story = {
     desktopBreakpoint: 992,
     desktopRight: (
       <>
-        <Link weight="semibold" href="/">
+        <Link size="md" weight="semibold" href="/">
           Sign in
         </Link>
         <Button size="sm" variant="outline" color="blue">

--- a/src/Link/Link.stories.tsx
+++ b/src/Link/Link.stories.tsx
@@ -36,6 +36,9 @@ export const Sizes: Story = {
   },
   render: ({ children }) => (
     <>
+      <Link href="#default" size="default">
+        {children}
+      </Link>
       <Link href="#sm" size="sm">
         {children}
       </Link>

--- a/src/Link/Link.stories.tsx
+++ b/src/Link/Link.stories.tsx
@@ -1,6 +1,8 @@
 import React, { Meta, StoryObj } from '@storybook/react';
 
 import { Link } from './Link';
+import { Text } from '../Text';
+import { VStack } from '../Stack';
 
 const meta: Meta<typeof Link> = {
   title: 'Actions/Link',
@@ -57,4 +59,38 @@ export const Sizes: Story = {
       </div>
     ),
   ],
+};
+
+export const InlineSize: Story = {
+  args: {
+    ...Base.args,
+  },
+  render: () => (
+    <VStack gap={6}>
+      <Text variant="body20">
+        Storybook is an industry-standard tool for UI development that hundreds
+        of thousands of developers rely on. Chromatic supercharges{' '}
+        <Link href="#default" size="default">
+          Storybook
+        </Link>{' '}
+        with automated testing and review workflows.
+      </Text>
+      <Text variant="body16">
+        Storybook is an industry-standard tool for UI development that hundreds
+        of thousands of developers rely on. Chromatic supercharges{' '}
+        <Link href="#default" size="default">
+          Storybook
+        </Link>{' '}
+        with automated testing and review workflows.
+      </Text>
+      <Text variant="body14">
+        Storybook is an industry-standard tool for UI development that hundreds
+        of thousands of developers rely on. Chromatic supercharges{' '}
+        <Link href="#default" size="default">
+          Storybook
+        </Link>{' '}
+        with automated testing and review workflows.
+      </Text>
+    </VStack>
+  ),
 };

--- a/src/Link/Link.tsx
+++ b/src/Link/Link.tsx
@@ -6,7 +6,7 @@ import type { Icons } from '../Icon/Icon';
 
 export interface LinkProps {
   children: string;
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'default' | 'sm' | 'md' | 'lg';
   color?: keyof typeof tokenColor;
   leftIcon?: Icons;
   rightIcon?: Icons;
@@ -35,6 +35,7 @@ const Container = styled.a<{
     return tokenColor.blue500;
   }};
   font-size: ${({ size }) => {
+    if (size === 'default') return '1em';
     if (size === 'sm') return '0.75rem';
     if (size === 'md') return '0.875rem';
     if (size === 'lg') return '1rem';
@@ -63,7 +64,7 @@ export const Link = forwardRef<
   (
     {
       children,
-      size = 'md',
+      size = 'default',
       color = 'blue500',
       leftIcon,
       rightIcon,


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.15.9--canary.74.d299a18.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/tetra@1.15.9--canary.74.d299a18.0
  # or 
  yarn add @chromaui/tetra@1.15.9--canary.74.d299a18.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
