### PR TITLE
SubNav: remove top divider to favor composing it in the app instead

### DIFF
--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -11,6 +11,7 @@ import { HeaderProps } from './types';
 import { minSm } from '../_helpers';
 import { LinkWithWrapper } from '../LinkWithWrapper';
 import { resetCSS } from '../_localHelpers/resetCSS';
+import { Divider } from '../Divider';
 
 interface WrapperProps {
   desktopBreakpoint?: HeaderProps['desktopBreakpoint'];
@@ -104,25 +105,28 @@ const HeaderWithProvider: FC = () => {
   const isMobile = breakpoint === false;
 
   return (
-    <Container>
-      <Wrapper desktopBreakpoint={desktopBreakpoint}>
-        <Left>
-          <LogoLink
-            href={logoHref || '/'}
-            LinkWrapper={logoLinkWrapper}
-            aria-label="Home"
-          >
-            <Logo
-              name={logo || 'chromatic'}
-              height={isDesktop ? logoHeightDesktop : logoHeightMobile}
-              theme={theme}
-            />
-          </LogoLink>
-          {isDesktop && <NavDesktop />}
-        </Left>
-        {isDesktop && <Right>{desktopRight}</Right>}
-        {isMobile && <NavMobile />}
-      </Wrapper>
-    </Container>
+    <>
+      <Container>
+        <Wrapper desktopBreakpoint={desktopBreakpoint}>
+          <Left>
+            <LogoLink
+              href={logoHref || '/'}
+              LinkWrapper={logoLinkWrapper}
+              aria-label="Home"
+            >
+              <Logo
+                name={logo || 'chromatic'}
+                height={isDesktop ? logoHeightDesktop : logoHeightMobile}
+                theme={theme}
+              />
+            </LogoLink>
+            {isDesktop && <NavDesktop />}
+          </Left>
+          {isDesktop && <Right>{desktopRight}</Right>}
+          {isMobile && <NavMobile />}
+        </Wrapper>
+      </Container>
+      <Divider inverse={theme === 'dark'} />
+    </>
   );
 };

--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -23,10 +23,6 @@ const Wrapper = styled.div<WrapperProps>`
   height: 72px;
   align-items: center;
   justify-content: space-between;
-
-  @media (min-width: ${({ desktopBreakpoint }) => desktopBreakpoint}px) {
-    height: calc(48px + 36px);
-  }
 `;
 
 const Left = styled.div`

--- a/src/SubNav/SubNav.tsx
+++ b/src/SubNav/SubNav.tsx
@@ -10,10 +10,8 @@ import { NavDropdownMenu } from '../NavDropdownMenu';
 
 const Wrapper = styled.div<{ variant?: 'light' | 'dark' }>`
   box-shadow: ${(props) =>
-        props.variant === 'dark' ? color.whiteTr10 : color.blackTr10}
-      0 -1px 0px 0px inset,
-    ${(props) => (props.variant === 'dark' ? color.whiteTr10 : color.blackTr10)}
-      0 1px 0px 0px inset;
+      props.variant === 'dark' ? color.whiteTr10 : color.blackTr10}
+    0 -1px 0px 0px inset;
 `;
 
 const SubNavLink = styled(LinkWithWrapper, {


### PR DESCRIPTION
I'm aiming to have this divider appear on every marketing layout even when the SubNav is not there. I'm removing the top divider in the SubNav because it would yield a double border.
<img width="1110" alt="image" src="https://github.com/chromaui/tetra/assets/263385/6c853b49-1d67-4cd3-a94a-3f19d6f5dff6">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.15.10--canary.75.3abe7e6.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/tetra@1.15.10--canary.75.3abe7e6.0
  # or 
  yarn add @chromaui/tetra@1.15.10--canary.75.3abe7e6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
