### PR TITLE
Update tsup.config.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,12 +82,12 @@
     "vite": "4.2.1"
   },
   "peerDependencies": {
+    "@storybook/theming": "^7.0.2",
     "framer-motion": "10.12.16",
     "react": ">=17",
     "react-dom": ">=17"
   },
   "dependencies": {
-    "@storybook/theming": "^7.0.2",
     "@radix-ui/react-collapsible": "1.0.2",
     "@radix-ui/react-dropdown-menu": "2.0.5",
     "@radix-ui/react-navigation-menu": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -82,12 +82,12 @@
     "vite": "4.2.1"
   },
   "peerDependencies": {
-    "@storybook/theming": "^7.0.2",
     "framer-motion": "10.12.16",
     "react": ">=17",
     "react-dom": ">=17"
   },
   "dependencies": {
+    "@storybook/theming": "^7.0.2",
     "@radix-ui/react-collapsible": "1.0.2",
     "@radix-ui/react-dropdown-menu": "2.0.5",
     "@radix-ui/react-navigation-menu": "1.1.2",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -20,5 +20,6 @@ export default defineConfig({
     '@radix-ui/react-popover',
     '@radix-ui/react-collapsible',
     'framer-motion',
+    '@emotion/*',
   ],
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,7 +19,5 @@ export default defineConfig({
     '@radix-ui/react-popover',
     '@radix-ui/react-collapsible',
     'framer-motion',
-    // '@storybook/theming',
-    // '@emotion/*',
   ],
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,11 +15,11 @@ export default defineConfig({
   // There is a bug in Radix - https://github.com/radix-ui/primitives/issues/1848
   // Remove this one when it's fixed
   noExternal: [
-    '@storybook/theming',
     '@radix-ui/react-navigation-menu',
     '@radix-ui/react-popover',
     '@radix-ui/react-collapsible',
     'framer-motion',
-    '@emotion/*',
+    // '@storybook/theming',
+    // '@emotion/*',
   ],
 });


### PR DESCRIPTION
Bad idea to put `@storybook/theming` into noExternal. After talking with @JReinhold, the good way is to add `@storybook/theming` as a dependency in Astro. This is not great but at least this should solve our issue for now.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.15.15--canary.80.dec0b7c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/tetra@1.15.15--canary.80.dec0b7c.0
  # or 
  yarn add @chromaui/tetra@1.15.15--canary.80.dec0b7c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
