### PR TITLE
Removes superfluous prop from Accordion’s StyledIcon

### DIFF
--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -135,9 +135,7 @@ const Trigger = styled(Acc.Trigger)<{
   }
 `;
 
-const StyledIcon = styled(Icon)<{
-  inverse?: boolean;
-}>`
+const StyledIcon = styled(Icon)`
   fill: currentColor;
   flex-basis: ${spacing[4]};
   flex-shrink: 0;
@@ -195,12 +193,7 @@ const AccordionTrigger = forwardRef<any, React.PropsWithChildren<TriggerProps>>(
     <Trigger ref={forwardedRef} inverse={inverse} {...props}>
       {children}
       {iconName && (
-        <StyledIcon
-          aria-hidden="true"
-          inverse={inverse}
-          name={iconName}
-          size={iconSize}
-        />
+        <StyledIcon aria-hidden="true" name={iconName} size={iconSize} />
       )}
     </Trigger>
   )


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.16.5--canary.88.869db7c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/tetra@1.16.5--canary.88.869db7c.0
  # or 
  yarn add @chromaui/tetra@1.16.5--canary.88.869db7c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
