### PR TITLE
Loosen peer dep to allow SB 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "vite": "4.2.1"
   },
   "peerDependencies": {
-    "@storybook/theming": "^7.0.2",
+    "@storybook/theming": "^7.0.2 || ^8.0.0-alpha.0",
     "framer-motion": "10.12.16",
     "react": ">=17",
     "react-dom": ">=17"


### PR DESCRIPTION
This is currently untested I am just trying to loosen dependencies for other reasons.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.16.10--canary.94.909fccc.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromaui/tetra@1.16.10--canary.94.909fccc.0
  # or 
  yarn add @chromaui/tetra@1.16.10--canary.94.909fccc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
