### PR TITLE
add the option to make header full width

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,14 @@
   "name": "@chromaui/tetra",
   "version": "1.18.0",
   "description": "Style Guide + UI library for Chromatic and Storybook marketing sites and docs",
-  "author": {
-    "name": "cdedreuille"
-  },
+  "contributors": [
+    {
+      "name": "winkervsbecks"
+    },
+    {
+      "name": "cdedreuille"
+    }
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@chromaui/tetra",
+  "name": "@chromatic-com/tetra",
   "version": "1.18.0",
   "description": "Style Guide + UI library for Chromatic and Storybook marketing sites and docs",
   "contributors": [

--- a/src/Container/Container.tsx
+++ b/src/Container/Container.tsx
@@ -1,6 +1,10 @@
+import React, { ReactNode } from 'react';
 import { styled } from '@storybook/theming';
 import { spacing } from '../_tokens';
-import { BlockWithOptionsForContainer } from '../_localHelpers';
+import {
+  BlockWithOptionsForContainer,
+  BlockWithOptionsForContainerProps,
+} from '../_localHelpers';
 import { min2xl, minSm, minXl } from '../_helpers';
 
 export const pageMargin = 5.55555;
@@ -30,3 +34,27 @@ export const Container = styled(BlockWithOptionsForContainer)`
     margin-right: ${pageMargin * 4}%;
   }
 `;
+
+const FullWidthInner = styled.div`
+  padding-left: ${spacing[5]};
+  padding-right: ${spacing[5]};
+  margin-left: ${spacing[3]};
+  margin-right: ${spacing[3]};
+`;
+
+const FullWidthOuter = styled(BlockWithOptionsForContainer)`
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1800px;
+`;
+
+export const FullWidthContainer = ({
+  children,
+  ...props
+}: BlockWithOptionsForContainerProps & {
+  children: ReactNode;
+}) => (
+  <FullWidthOuter {...props}>
+    <FullWidthInner>{children}</FullWidthInner>
+  </FullWidthOuter>
+);

--- a/src/Container/index.ts
+++ b/src/Container/index.ts
@@ -1,1 +1,1 @@
-export { Container } from './Container';
+export { Container, FullWidthContainer } from './Container';

--- a/src/Header/Header.stories.tsx
+++ b/src/Header/Header.stories.tsx
@@ -248,3 +248,33 @@ export const MobileOpen: Story = {
     await userEvent.click(MenuButton);
   },
 };
+
+export const DesktopFullWidth: Story = {
+  args: {
+    ...DesktopLight.args,
+    fullWidth: true,
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export const MobileFullWidth: Story = {
+  args: {
+    ...DesktopLight.args,
+  },
+  parameters: {
+    layout: 'fullscreen',
+    viewport: {
+      defaultViewport: 'xsm',
+    },
+  },
+  decorators: DesktopLightOpen.decorators,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const MenuButton = await canvas.findByRole('button', {
+      name: 'Toggle Menu',
+    });
+    await userEvent.click(MenuButton);
+  },
+};

--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -3,7 +3,7 @@ import { styled } from '@storybook/theming';
 import { HeaderProvider, useHeaderContext } from './context';
 import { HeaderLogo } from './HeaderLogo';
 import { spacing } from '../_tokens';
-import { Container } from '../Container';
+import { Container, FullWidthContainer } from '../Container';
 import { NavDesktop } from './NavDesktop';
 import { NavMobile } from './NavMobile';
 import { HeaderProps } from './types';
@@ -79,6 +79,7 @@ export const Header: FC<HeaderProps> = ({
   mobileData,
   mobileBottom,
   mobileTop,
+  fullWidth = false,
 }) => {
   return (
     <HeaderProvider
@@ -93,17 +94,21 @@ export const Header: FC<HeaderProps> = ({
       mobileTop={mobileTop}
       mobileBottom={mobileBottom}
     >
-      <HeaderWithProvider />
+      <HeaderWithProvider fullWidth={fullWidth} />
     </HeaderProvider>
   );
 };
 
-const HeaderWithProvider: FC = () => {
+const HeaderWithProvider: FC<{
+  fullWidth?: boolean;
+}> = ({ fullWidth = false }) => {
   const { theme, logoHref, logoLinkWrapper, desktopRight } = useHeaderContext();
+
+  const HeaderContainer = fullWidth ? FullWidthContainer : Container;
 
   return (
     <>
-      <Container>
+      <HeaderContainer>
         <Wrapper>
           <Left>
             <LogoLink
@@ -122,7 +127,7 @@ const HeaderWithProvider: FC = () => {
             <NavMobile />
           </MobileOnly>
         </Wrapper>
-      </Container>
+      </HeaderContainer>
       <Divider inverse={theme === 'dark'} />
     </>
   );

--- a/src/Header/types.ts
+++ b/src/Header/types.ts
@@ -50,4 +50,5 @@ export interface HeaderProps {
   mobileData: HeaderMobileSection[];
   mobileTop?: ReactNode;
   mobileBottom?: ReactNode;
+  fullWidth?: boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export { useMediaQuery } from './_hooks/useMediaQuery';
 // Components
 export { Accordion } from './Accordion';
 export { Avatar } from './Avatar';
-export { Container } from './Container';
+export { Container, FullWidthContainer } from './Container';
 export { Button } from './Button';
 export { CustomerStoryHero } from './CustomerStoryHero';
 export { Divider } from './Divider';


### PR DESCRIPTION
Also moved the package to the new npm org `@chromatic-com`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.19.0--canary.99.43e802b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/tetra@1.19.0--canary.99.43e802b.0
  # or 
  yarn add @chromatic-com/tetra@1.19.0--canary.99.43e802b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
