### PR TITLE
Loosen peer dep to allow SB 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "vite": "4.2.1"
   },
   "peerDependencies": {
-    "@storybook/theming": "^7.6.6",
+    "@storybook/theming": "^7.6.6 || ^8.2.9",
     "framer-motion": "^11.0.3",
     "react": ">=17",
     "react-dom": ">=17"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.19.3--canary.105.17e3f46.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/tetra@1.19.3--canary.105.17e3f46.0
  # or 
  yarn add @chromatic-com/tetra@1.19.3--canary.105.17e3f46.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
