### PR TITLE
Add 500ms play function delay to stories with background globals

### DIFF
--- a/src/Accordion/Accordion.stories.tsx
+++ b/src/Accordion/Accordion.stories.tsx
@@ -62,6 +62,9 @@ export const Base: Story = {
   globals: {
     backgrounds: { value: 'light' },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
   parameters: {
     chromatic: {
       viewports: [320, 640, 768, 1024],
@@ -91,6 +94,9 @@ export const Inverse: Story = {
   },
   globals: {
     backgrounds: { value: 'dark' },
+  },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
   },
   parameters: {
     chromatic: {
@@ -220,6 +226,9 @@ export const GroupInverse: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
   parameters: {
     chromatic: {
       viewports: [320, 640, 768, 1024],
@@ -292,6 +301,9 @@ export const GroupOpenStartInverse: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
   render: (args) => {
     return (
       <Accordion defaultValue="item-0" inverse={args.inverse}>
@@ -325,6 +337,9 @@ export const GroupWithAlternateIcons: Story = {
   },
   globals: {
     backgrounds: { value: 'light' },
+  },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
   },
   render: (args) => {
     return (

--- a/src/Divider/Divider.stories.tsx
+++ b/src/Divider/Divider.stories.tsx
@@ -38,4 +38,7 @@ export const Inverse: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
 };

--- a/src/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/DropdownMenu/DropdownMenu.stories.tsx
@@ -42,6 +42,9 @@ export const ClosedDark: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
 };
 
 export const LabelWithIconLight: Story = {
@@ -72,6 +75,13 @@ export const LabelWithIconDark: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async ({ canvasElement, userEvent }) => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const canvas = within(canvasElement);
+    const MenuButton = await canvas.findByRole('button');
+    MenuButton.focus();
+    await userEvent.keyboard('{enter}');
+  },
 };
 
 export const DisabledItemsLight: Story = {
@@ -95,6 +105,13 @@ export const DisabledItemsDark: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async ({ canvasElement, userEvent }) => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const canvas = within(canvasElement);
+    const MenuButton = await canvas.findByRole('button');
+    MenuButton.focus();
+    await userEvent.keyboard('{enter}');
+  },
 };
 
 export const CheckboxItemsLight: Story = {
@@ -117,6 +134,13 @@ export const CheckboxItemsDark: Story = {
   },
   globals: {
     backgrounds: { value: 'dark' },
+  },
+  play: async ({ canvasElement, userEvent }) => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const canvas = within(canvasElement);
+    const MenuButton = await canvas.findByRole('button');
+    MenuButton.focus();
+    await userEvent.keyboard('{enter}');
   },
 };
 

--- a/src/Form/Form.stories.tsx
+++ b/src/Form/Form.stories.tsx
@@ -99,4 +99,7 @@ export const Inverse: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
 };

--- a/src/Form/Input.stories.tsx
+++ b/src/Form/Input.stories.tsx
@@ -68,4 +68,7 @@ export const Inverse: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
 };

--- a/src/Form/Label.stories.tsx
+++ b/src/Form/Label.stories.tsx
@@ -28,4 +28,7 @@ export const Inverse: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
 };

--- a/src/Form/Range.stories.tsx
+++ b/src/Form/Range.stories.tsx
@@ -85,4 +85,7 @@ export const Inverse: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
 };

--- a/src/Form/Select.stories.tsx
+++ b/src/Form/Select.stories.tsx
@@ -78,4 +78,7 @@ export const Inverse: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
 };

--- a/src/Header/Header.stories.tsx
+++ b/src/Header/Header.stories.tsx
@@ -44,6 +44,9 @@ export const DesktopDark: Story = {
   parameters: {
     ...DesktopLight.parameters,
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
 };
 
 export const DesktopLightSticky: Story = {
@@ -61,6 +64,9 @@ export const DesktopDarkSticky: Story = {
   },
   globals: {
     backgrounds: { value: 'dark' },
+  },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
   },
 };
 
@@ -85,6 +91,9 @@ export const DesktopDarkLoggedIn: Story = {
   },
   globals: {
     backgrounds: { value: 'dark' },
+  },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
   },
 };
 
@@ -134,6 +143,9 @@ export const WithSubNav: Story = {
   parameters: {
     ...DesktopLight.parameters,
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
 };
 
 export const DesktopLightActive: Story = {
@@ -157,6 +169,9 @@ export const DesktopDarkActive: Story = {
   },
   parameters: {
     ...DesktopLight.parameters,
+  },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
   },
 };
 
@@ -195,6 +210,7 @@ export const DesktopDarkOpen: Story = {
   },
   decorators: DesktopLightOpen.decorators,
   play: async ({ canvasElement }) => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
     const canvas = within(canvasElement);
     const MenuButton = await canvas.findByRole('button', {
       name: 'Platform',
@@ -215,6 +231,9 @@ export const TabletLight: Story = {
   parameters: {
     chromatic: { viewports: [320, 640, 768, 939] },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
 };
 
 export const TabletDark: Story = {
@@ -228,6 +247,9 @@ export const TabletDark: Story = {
   },
   parameters: {
     chromatic: { viewports: [320, 640, 768, 939] },
+  },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
   },
 };
 

--- a/src/NavDropdownMenu/NavDropdownMenu.stories.tsx
+++ b/src/NavDropdownMenu/NavDropdownMenu.stories.tsx
@@ -42,5 +42,8 @@ export const Dark: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
-  play: Light.play,
+  play: async (context) => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await Light.play?.(context);
+  },
 };

--- a/src/Stat/Stat.stories.tsx
+++ b/src/Stat/Stat.stories.tsx
@@ -98,6 +98,9 @@ export const CustomColorInverse: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
 };
 
 export const Loading: Story = {

--- a/src/SubNav/SubNav.stories.tsx
+++ b/src/SubNav/SubNav.stories.tsx
@@ -36,6 +36,9 @@ export const Dark: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
 };
 
 export const Collapsed: Story = {
@@ -49,6 +52,7 @@ export const Collapsed: Story = {
     chromatic: { viewports: [320] },
   },
   play: async ({ canvasElement }) => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
     const canvas = within(canvasElement);
     const MenuButton = await canvas.findByRole('button', {
       name: 'Features',

--- a/src/Testimonial/Testimonial.stories.tsx
+++ b/src/Testimonial/Testimonial.stories.tsx
@@ -41,6 +41,9 @@ export const Inverse: Story = {
   globals: {
     backgrounds: { value: 'dark' },
   },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  },
 };
 
 export const Compact: Story = {
@@ -53,6 +56,9 @@ export const Compact: Story = {
   },
   parameters: {
     layout: 'padded',
+  },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
   },
 };
 
@@ -76,6 +82,9 @@ export const InverseLeftAlign: Story = {
   },
   parameters: {
     layout: 'padded',
+  },
+  play: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
   },
 };
 


### PR DESCRIPTION
Stories that set a background global value have a transition animation for the background color change. Adding a 500ms delay in the play function ensures the animation completes before any visual snapshots are captured. For stories that already had play functions, the delay is prepended before the existing logic.

https://claude.ai/code/session_01LsPhCpxcDayqLEJhZ7jFqJ