### PR TITLE
Fix mobile menu scroll when accordions are expanded

### DIFF
--- a/src/Header/Header.stories.tsx
+++ b/src/Header/Header.stories.tsx
@@ -309,6 +309,28 @@ export const MobileOpen: Story = {
   },
 };
 
+export const MobileOpenTall: Story = {
+  ...MobileOpen,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const MenuButton = await canvas.findByRole('button', {
+      name: 'Toggle Menu',
+    });
+    await userEvent.click(MenuButton);
+
+    const sections = ['View more', 'Integrations', 'Use cases', 'Customer Stories', 'Company'];
+    for (const section of sections) {
+      const buttons = document.querySelectorAll('button');
+      for (const btn of buttons) {
+        if (btn.textContent?.trim().startsWith(section)) {
+          await userEvent.click(btn);
+          break;
+        }
+      }
+    }
+  },
+};
+
 export const DesktopFullWidth: Story = {
   args: {
     ...DesktopLight.args,

--- a/src/Header/NavMobile.tsx
+++ b/src/Header/NavMobile.tsx
@@ -30,6 +30,8 @@ const NavigationMenu = styled(motion.div)`
   margin-right: ${spacing[4]};
   padding: 12px;
   z-index: 100;
+  max-height: calc(100vh - ${spacing[20]});
+  overflow-y: auto;
 
   ${minSm} {
     margin-right: ${spacing[12]};


### PR DESCRIPTION
I noticed the mobile navigation menu on the [marketing site](https://www.chromatic.com/) doesn't scroll when multiple accordion sections are expanded, making lower menu items unreachable.

Adds:
- `max-height` and `overflow-y: auto` to the menu container, making the menu scrollable and all links reachable.
- Story for fully expanded mobile menu

<img width="679" height="856" alt="image" src="https://github.com/user-attachments/assets/719e47d0-14ac-465c-a08a-1e0b34dbf7fa" />

