### PR TITLE
docs: remove decorative glyphs from README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tetra ⍜ ⍚
+# Tetra
 
 <img src="public/cover.jpg" />
 


### PR DESCRIPTION
## Summary

Removes the `⍜ ⍚` glyphs from the `# Tetra` heading in `README.md`.

```diff
-# Tetra ⍜ ⍚
+# Tetra
```

## Verification

- Docs-only change to `README.md`; no code paths touched, so `lint` / `type-check` / tests are not applicable.
- Verified the diff is limited to the heading line and the rest of the README is untouched.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.2.15--canary.149.383f0af.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/tetra@3.2.15--canary.149.383f0af.0
  # or 
  yarn add @chromatic-com/tetra@3.2.15--canary.149.383f0af.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
