### PR TITLE
docs: remove decorative glyphs from README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tetra ⍜ ⍚
+# Tetra
 
 <img src="public/cover.jpg" />
 


### PR DESCRIPTION
## Summary

Removes the `⍜ ⍚` glyphs from the `# Tetra` heading in `README.md`, per #151.

## Diff

```diff
-# Tetra ⍜ ⍚
+# Tetra
```

## Verification

- Confirmed the only occurrences of `⍜` / `⍚` in the repo were on line 1 of `README.md` (`rg '⍜|⍚'` returned no matches after the edit).
- Docs-only change; no code, types, stories, or build output affected, so `lint` / `type-check` / tests are not relevant to the change.

Closes #151
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.2.15--canary.153.5c15f5f.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/tetra@3.2.15--canary.153.5c15f5f.0
  # or 
  yarn add @chromatic-com/tetra@3.2.15--canary.153.5c15f5f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
