### PR TITLE
docs: remove decorative symbols from README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tetra ⍜ ⍚
+# Tetra
 
 <img src="public/cover.jpg" />
 


### PR DESCRIPTION
## Summary

Removes the decorative APL-style symbols (`⍜ ⍚`) from the `# Tetra` heading in `README.md`, leaving a clean `# Tetra` title.

```diff
-# Tetra ⍜ ⍚
+# Tetra
```

## Verified

- Diff is a single-line change to `README.md`; no code paths affected.
- No lint/type-check/tests required for a docs-only change to the top-level README.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.2.15--canary.154.16fe967.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/tetra@3.2.15--canary.154.16fe967.0
  # or 
  yarn add @chromatic-com/tetra@3.2.15--canary.154.16fe967.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
