### PR TITLE
docs(_helpers): add Typography story documenting typography.ts

### DIFF
--- a/src/_helpers/Typography.stories.tsx
+++ b/src/_helpers/Typography.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import styled from '@emotion/styled';
+import { color } from '../_tokens/tokens';
+import { typography, t, type ListTypes } from './typography';
+
+const Page = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 24px 0;
+`;
+
+const Specimen = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid ${color.slate200};
+`;
+
+const Caption = styled.div`
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: ${color.slate700};
+`;
+
+type SpecimenKey = keyof typeof typography;
+
+const sample = 'Sphinx of black quartz, judge my vow.';
+
+const Line = styled.div<{ variant: SpecimenKey }>`
+  ${({ variant }) => typography[variant]}
+`;
+
+const Sample: React.FC<{
+  variant: SpecimenKey;
+  children?: React.ReactNode;
+}> = ({ variant, children }) => {
+  const meta = (t as Record<string, (typeof t)[ListTypes] | undefined>)[
+    variant
+  ];
+
+  return (
+    <Specimen>
+      <Caption>
+        typography.{variant}
+        {meta
+          ? ` — ${meta.fontSize}px / ${meta.lineHeight}px / ${meta.fontWeight}`
+          : ' — css helper only (not in `t`)'}
+      </Caption>
+      <Line variant={variant}>{children ?? sample}</Line>
+    </Specimen>
+  );
+};
+
+const headings: SpecimenKey[] = [
+  'heading56',
+  'heading48',
+  'heading40',
+  'heading36',
+  'heading30',
+  'heading24',
+  'heading20',
+  'heading18',
+  'heading16',
+];
+
+const body: SpecimenKey[] = ['body20', 'body18', 'body16', 'body14'];
+
+const subheadings: SpecimenKey[] = ['subheadingLarge', 'subheading'];
+
+const meta = {
+  title: 'Typography/Helpers',
+  parameters: {
+    docs: {
+      description: {
+        component: [
+          'Visual reference for the exports of `src/_helpers/typography.ts`.',
+          '',
+          '- `typography` — Emotion `css` helpers for use inside any `styled` component (`${typography.heading24}`).',
+          '- `t` — Plain-data lookup of font-size, line-height, font-weight, and font-family per variant. Drives the `Text` component.',
+          '- `ListTypes` — Union of variant names available on `t`.',
+          '',
+          'Note: `subheading` and `subheadingLarge` are exposed as CSS helpers on `typography` only and are not part of `t` / `ListTypes`.',
+        ].join('\n'),
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Headings: Story = {
+  render: () => (
+    <Page>
+      {headings.map((key) => (
+        <Sample key={key} variant={key} />
+      ))}
+    </Page>
+  ),
+};
+
+export const Body: Story = {
+  render: () => (
+    <Page>
+      {body.map((key) => (
+        <Sample key={key} variant={key} />
+      ))}
+    </Page>
+  ),
+};
+
+export const Subheadings: Story = {
+  render: () => (
+    <Page>
+      {subheadings.map((key) => (
+        <Sample key={key} variant={key}>
+          Section label
+        </Sample>
+      ))}
+    </Page>
+  ),
+};
+
+export const All: Story = {
+  name: 'All helpers',
+  render: () => (
+    <Page>
+      {(Object.keys(typography) as SpecimenKey[]).map((key) => (
+        <Sample key={key} variant={key} />
+      ))}
+    </Page>
+  ),
+};


### PR DESCRIPTION
## Summary

Adds `src/_helpers/Typography.stories.tsx` — a Storybook story that visually documents every export of `src/_helpers/typography.ts`:

- **`typography`** — the Emotion `css` helpers for use inside `styled` components. Each variant (`heading56` … `heading16`, `body20` … `body14`, `subheading`, `subheadingLarge`) is rendered with sample text.
- **`t`** — the plain-data lookup that drives the `Text` component. Surfaced as a caption on each specimen showing `fontSize / lineHeight / fontWeight`.
- **`ListTypes`** — the union of variants available on `t`. Used as the typed map for the specimen table.

The story lives under the existing `Typography/` group in Storybook (alongside `Typography/Docs` and `Typography/Text Component`) with four named stories — `Headings`, `Body`, `Subheadings`, `All helpers` — plus the autodocs page.

### Why this is useful

The existing `Typography/Docs` page renders the `t` object via `TypographyHelper`, which means `subheading` and `subheadingLarge` (CSS-only entries on the `typography` export, intentionally not part of `t` / `ListTypes`) had no visual presence in Storybook. The new story makes those discoverable and clarifies the relationship between the three exports of the file.

## Verification

- `pnpm run lint` — clean for the new file.
- `pnpm run type-check` — no errors introduced by the new file (pre-existing errors in `Header/NavMobile.tsx` are unchanged and unrelated).
- `pnpm exec prettier --check src/_helpers/Typography.stories.tsx` — passes.
- Storybook MCP `run-story-tests` (with a11y) for all four new stories — all pass.

### Story preview URLs (local Storybook on `:6006`)

- [`Typography/Helpers/Headings`](http://localhost:6006/?path=/story/typography-helpers--headings)
- [`Typography/Helpers/Body`](http://localhost:6006/?path=/story/typography-helpers--body)
- [`Typography/Helpers/Subheadings`](http://localhost:6006/?path=/story/typography-helpers--subheadings)
- [`Typography/Helpers/All helpers`](http://localhost:6006/?path=/story/typography-helpers--all)
- [`Typography/Helpers` autodocs page](http://localhost:6006/?path=/docs/typography-helpers--docs)

## Notes / decisions

- Caption text uses `color.slate700` to satisfy WCAG AA contrast at the 12px monospace caption size (the initial `slate500` choice flagged a serious axe color-contrast violation; this is a fresh utility label, not a redesign of existing UI, so the token was selected directly rather than escalating).
- The story does not reuse the existing `TypographyHelper` local component — it deliberately keys off `typography` (not `t`) so the two CSS-only helpers are visible. The existing `Typography/Docs` page and `Local/Typography Helpers` story are unchanged.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.2.16--canary.155.df374a6.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @chromatic-com/tetra@3.2.16--canary.155.df374a6.0
  # or 
  yarn add @chromatic-com/tetra@3.2.16--canary.155.df374a6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
