### PR TITLE
fix(a11y): patch Radix FocusGuard tabindex to resolve aria-hidden-focus

### DIFF
--- a/src/Header/NavDesktop.tsx
+++ b/src/Header/NavDesktop.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React, { FC, useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import { NavDesktopLink } from './NavDesktopLink';
 import { NavDesktopTrigger } from './NavDesktopTrigger';
@@ -36,16 +36,16 @@ export const NavDesktop = ({ links, fullWidth, ...props }: NavDesktopProps) => {
     [links, fullWidth]
   );
 
-  // @radix-ui/react-navigation-menu@1.1.2 renders two FocusGuard spans with
-  // aria-hidden="true" + tabindex="0" at the Root level. tabindex="0" makes
-  // them keyboard-reachable while aria-hidden hides them from AT, which axe
-  // flags as aria-hidden-focus. Patching to tabindex="-1" keeps the sentinel
-  // elements reachable via programmatic focus (needed for Radix's logic) but
-  // removes them from the natural tab order.
+  // @radix-ui/react-navigation-menu@1.1.2 renders FocusGuard spans with
+  // aria-hidden="true" + tabindex="0", which axe flags as aria-hidden-focus.
+  // Patching to tabindex="-1" removes them from the tab order while keeping
+  // them reachable via programmatic focus for Radix's internal logic.
   const rootRef = useCallback((node: HTMLElement | null) => {
     if (!node) return;
     node
-      .querySelectorAll<HTMLSpanElement>('span[aria-hidden="true"][tabindex="0"]')
+      .querySelectorAll<HTMLSpanElement>(
+        'span[aria-hidden="true"][tabindex="0"]'
+      )
       .forEach((span) => span.setAttribute('tabindex', '-1'));
   }, []);
 

--- a/src/Header/NavDesktop.tsx
+++ b/src/Header/NavDesktop.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import React, { FC, useMemo } from 'react';
+import React, { FC, useCallback, useMemo } from 'react';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import { NavDesktopLink } from './NavDesktopLink';
 import { NavDesktopTrigger } from './NavDesktopTrigger';
@@ -36,8 +36,21 @@ export const NavDesktop = ({ links, fullWidth, ...props }: NavDesktopProps) => {
     [links, fullWidth]
   );
 
+  // @radix-ui/react-navigation-menu@1.1.2 renders two FocusGuard spans with
+  // aria-hidden="true" + tabindex="0" at the Root level. tabindex="0" makes
+  // them keyboard-reachable while aria-hidden hides them from AT, which axe
+  // flags as aria-hidden-focus. Patching to tabindex="-1" keeps the sentinel
+  // elements reachable via programmatic focus (needed for Radix's logic) but
+  // removes them from the natural tab order.
+  const rootRef = useCallback((node: HTMLElement | null) => {
+    if (!node) return;
+    node
+      .querySelectorAll<HTMLSpanElement>('span[aria-hidden="true"][tabindex="0"]')
+      .forEach((span) => span.setAttribute('tabindex', '-1'));
+  }, []);
+
   return (
-    <NavigationMenuRoot delayDuration={100} {...props}>
+    <NavigationMenuRoot ref={rootRef} delayDuration={100} {...props}>
       <NavigationMenuList>
         {desktopLinks &&
           desktopLinks.map((item) => (

--- a/src/Header/NavDesktopTrigger.tsx
+++ b/src/Header/NavDesktopTrigger.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useRef } from 'react';
+import React, { FC } from 'react';
 import styled from '@emotion/styled';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import { Icon } from '../Icon/Icon';
@@ -64,31 +64,6 @@ const NavigationMenuContent = styled.div<{
 export const NavDesktopTrigger: FC<DesktopItemProps> = ({ item }) => {
   const { theme, desktopActiveId } = useHeaderContext();
   const isActive = desktopActiveId ? desktopActiveId === item.id : false;
-  const observerRef = useRef<MutationObserver | null>(null);
-
-  const contentRef = useCallback((node: HTMLDivElement | null) => {
-    if (observerRef.current) {
-      observerRef.current.disconnect();
-      observerRef.current = null;
-    }
-
-    if (!node) return;
-
-    const sync = () => {
-      if (node.getAttribute('data-state') === 'closed') {
-        node.setAttribute('inert', '');
-      } else {
-        node.removeAttribute('inert');
-      }
-    };
-
-    sync();
-    observerRef.current = new MutationObserver(sync);
-    observerRef.current.observe(node, {
-      attributes: true,
-      attributeFilter: ['data-state'],
-    });
-  }, []);
 
   return (
     <>
@@ -99,7 +74,7 @@ export const NavDesktopTrigger: FC<DesktopItemProps> = ({ item }) => {
         </CaretDown>
       </NavigationMenuTrigger>
       <NavigationMenu.Content asChild>
-        <NavigationMenuContent ref={contentRef} leftPosition={item.leftPosition}>
+        <NavigationMenuContent leftPosition={item.leftPosition}>
           <NavDesktopContent item={item} />
         </NavigationMenuContent>
       </NavigationMenu.Content>

--- a/src/Header/NavDesktopTrigger.tsx
+++ b/src/Header/NavDesktopTrigger.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useRef } from 'react';
 import styled from '@emotion/styled';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import { Icon } from '../Icon/Icon';
@@ -64,6 +64,25 @@ const NavigationMenuContent = styled.div<{
 export const NavDesktopTrigger: FC<DesktopItemProps> = ({ item }) => {
   const { theme, desktopActiveId } = useHeaderContext();
   const isActive = desktopActiveId ? desktopActiveId === item.id : false;
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+
+    const sync = () => {
+      if (el.dataset.state === 'closed') {
+        el.setAttribute('inert', '');
+      } else {
+        el.removeAttribute('inert');
+      }
+    };
+
+    sync();
+    const observer = new MutationObserver(sync);
+    observer.observe(el, { attributes: true, attributeFilter: ['data-state'] });
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <>
@@ -74,7 +93,7 @@ export const NavDesktopTrigger: FC<DesktopItemProps> = ({ item }) => {
         </CaretDown>
       </NavigationMenuTrigger>
       <NavigationMenu.Content asChild>
-        <NavigationMenuContent leftPosition={item.leftPosition}>
+        <NavigationMenuContent ref={contentRef} leftPosition={item.leftPosition}>
           <NavDesktopContent item={item} />
         </NavigationMenuContent>
       </NavigationMenu.Content>

--- a/src/Header/NavDesktopTrigger.tsx
+++ b/src/Header/NavDesktopTrigger.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef } from 'react';
+import React, { FC, useCallback, useRef } from 'react';
 import styled from '@emotion/styled';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import { Icon } from '../Icon/Icon';
@@ -64,24 +64,30 @@ const NavigationMenuContent = styled.div<{
 export const NavDesktopTrigger: FC<DesktopItemProps> = ({ item }) => {
   const { theme, desktopActiveId } = useHeaderContext();
   const isActive = desktopActiveId ? desktopActiveId === item.id : false;
-  const contentRef = useRef<HTMLDivElement>(null);
+  const observerRef = useRef<MutationObserver | null>(null);
 
-  useEffect(() => {
-    const el = contentRef.current;
-    if (!el) return;
+  const contentRef = useCallback((node: HTMLDivElement | null) => {
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+    }
+
+    if (!node) return;
 
     const sync = () => {
-      if (el.dataset.state === 'closed') {
-        el.setAttribute('inert', '');
+      if (node.getAttribute('data-state') === 'closed') {
+        node.setAttribute('inert', '');
       } else {
-        el.removeAttribute('inert');
+        node.removeAttribute('inert');
       }
     };
 
     sync();
-    const observer = new MutationObserver(sync);
-    observer.observe(el, { attributes: true, attributeFilter: ['data-state'] });
-    return () => observer.disconnect();
+    observerRef.current = new MutationObserver(sync);
+    observerRef.current.observe(node, {
+      attributes: true,
+      attributeFilter: ['data-state'],
+    });
   }, []);
 
   return (


### PR DESCRIPTION
## Summary

Fixes the `aria-hidden-focus` accessibility violation reported in [chromaui/marketing#80](https://github.com/chromaui/marketing/issues/80).

**Root cause:** `@radix-ui/react-navigation-menu@1.1.2` renders two sentinel `<span aria-hidden="true" tabindex="0">` elements (FocusGuard) at the `NavigationMenu.Root` level to detect when keyboard focus enters or exits the nav. The `tabindex="0"` makes them reachable via Tab while `aria-hidden="true"` hides them from assistive technology — axe flags this as a `serious` `aria-hidden-focus` violation.

**Fix:** Patch the offending sentinel spans in place via a callback ref on `NavigationMenu.Root`. We rewrite their `tabindex` from `0` to `-1`, which removes them from the tab order (resolving the axe violation) while keeping them reachable via Radix's programmatic focus for its internal focus-tracking logic. Upgrading the Radix package was considered but deferred — the patch keeps the dependency change minimal.

## Changes

- `src/Header/NavDesktop.tsx` — add a `useCallback` ref on `NavigationMenuRoot` that queries for `span[aria-hidden="true"][tabindex="0"]` descendants and rewrites their `tabindex` to `-1`

## Test plan

- [ ] Run Storybook a11y tests on `Header | Desktop Features Open` and `Header | Desktop Use Cases Open` — expect 0 `aria-hidden-focus` violations
- [ ] Tab through the open header — confirm focus never lands on a hidden sentinel span
- [ ] Open and close dropdown panels — confirm keyboard navigation still works (focus returns correctly after closing a panel)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.2.17--canary.156.a07b1fc.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:

  ```bash
  npm install @chromatic-com/tetra@3.2.17--canary.156.a07b1fc.0
  # or
  yarn add @chromatic-com/tetra@3.2.17--canary.156.a07b1fc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
